### PR TITLE
feat: update SDK spec and bump version to 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-01-16
+
+### Added
+- `agent` option for specifying main thread agent name (TypeScript SDK v0.2.9 parity)
+- `model` field in `SessionStartInput` hook input
+
 ## [0.2.0] - 2026-01-11
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    claude_agent (0.2.0)
+    claude_agent (0.3.0)
       activesupport (>= 7.0)
 
 GEM
@@ -125,7 +125,7 @@ CHECKSUMS
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.0.1) sha256=8b07d3d065a9f921c80ceaea7c9d4ae596697295b584c296fe599dd0ad01c4a7
-  claude_agent (0.2.0)
+  claude_agent (0.3.0)
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0

--- a/SPEC.md
+++ b/SPEC.md
@@ -3,8 +3,8 @@
 This document provides a comprehensive specification of the Claude Agent SDK, comparing feature parity across the official TypeScript and Python SDKs with this Ruby implementation.
 
 **Reference Versions:**
-- TypeScript SDK: v0.2.7 (npm package)
-- Python SDK: Latest from GitHub (commit 8602ff4)
+- TypeScript SDK: v0.2.9 (npm package)
+- Python SDK: v0.1.20 from GitHub (commit 04da88d)
 - Ruby SDK: This repository
 
 ---
@@ -65,6 +65,7 @@ Configuration options for SDK queries and clients.
 | `settingSources`                  |     ✅      |   ✅    |  ✅   | Which settings to load                                      |
 | `plugins`                         |     ✅      |   ✅    |  ✅   | Plugin configurations                                       |
 | `betas`                           |     ✅      |   ✅    |  ✅   | Beta features (e.g., context-1m-2025-08-07)                 |
+| `agent`                           |     ✅      |   ❌    |  ✅   | Agent name for main thread                                  |
 | `abortController`                 |     ✅      |   ❌    |  ✅   | Cancellation controller                                     |
 | `stderr`                          |     ✅      |   ✅    |  ✅   | Stderr callback                                             |
 | `spawnClaudeCodeProcess`          |     ✅      |   ❌    |  ✅   | Custom spawn function                                       |
@@ -542,12 +543,13 @@ Public API surface for SDK clients.
 - Primary reference for API surface (most comprehensive)
 - Source is bundled/minified, but `sdk.d.ts` provides complete type definitions
 - Includes unstable V2 session API
-- Version 0.2.7 includes `maxOutputTokens` field in `ModelUsage`
+- Version 0.2.9 adds `agent` option for specifying main thread agent
 - Adds `deno` as supported executable option
 - Includes experimental `criticalSystemReminder_EXPERIMENTAL` for agent definitions
+- `SessionStartHookInput` includes `model` field
 
 ### Python SDK
-- Full source available
+- Full source available (v0.1.20)
 - Fewer control protocol features than TypeScript
 - Does not support SessionStart/SessionEnd/Notification hooks due to setup limitations
 - Missing several permission modes (delegate, dontAsk)

--- a/lib/claude_agent/hooks.rb
+++ b/lib/claude_agent/hooks.rb
@@ -141,14 +141,16 @@ module ClaudeAgent
   # Input for SessionStart hook (TypeScript SDK parity)
   #
   class SessionStartInput < BaseHookInput
-    attr_reader :source, :agent_type
+    attr_reader :source, :agent_type, :model
 
     # @param source [String] One of: "startup", "resume", "clear", "compact"
     # @param agent_type [String, nil] Type of agent if running in subagent context
-    def initialize(source:, agent_type: nil, **kwargs)
+    # @param model [String, nil] Model being used for this session
+    def initialize(source:, agent_type: nil, model: nil, **kwargs)
       super(hook_event_name: "SessionStart", **kwargs)
       @source = source
       @agent_type = agent_type
+      @model = model
     end
   end
 

--- a/lib/claude_agent/options.rb
+++ b/lib/claude_agent/options.rb
@@ -50,7 +50,7 @@ module ClaudeAgent
       continue_conversation resume fork_session resume_session_at
       max_turns max_budget_usd max_thinking_tokens
       strict_mcp_config mcp_servers hooks
-      settings sandbox cwd add_dirs env user
+      settings sandbox cwd add_dirs env user agent
       cli_path extra_args agents setting_sources plugins
       include_partial_messages output_format enable_file_checkpointing
       persist_session betas max_buffer_size stderr_callback
@@ -206,6 +206,7 @@ module ClaudeAgent
     def environment_args
       [].tap do |args|
         args.push("--user", user) if user
+        args.push("--agent", agent) if agent
         add_dirs.each { |dir| args.push("--add-dir", dir.to_s) }
         args.push("--setting-sources", setting_sources.join(",")) if setting_sources&.any?
         plugins.each do |plugin|

--- a/lib/claude_agent/version.rb
+++ b/lib/claude_agent/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ClaudeAgent
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end

--- a/sig/claude_agent.rbs
+++ b/sig/claude_agent.rbs
@@ -279,6 +279,7 @@ module ClaudeAgent
     attr_accessor add_dirs: Array[String]
     attr_accessor env: Hash[String, String]
     attr_accessor user: String?
+    attr_accessor agent: String?
 
     # CLI configuration
     attr_accessor cli_path: String?
@@ -633,8 +634,9 @@ module ClaudeAgent
   class SessionStartInput < BaseHookInput
     attr_reader source: String
     attr_reader agent_type: String?
+    attr_reader model: String?
 
-    def initialize: (source: String, ?agent_type: String?, **untyped) -> void
+    def initialize: (source: String, ?agent_type: String?, ?model: String?, **untyped) -> void
   end
 
   class SessionEndInput < BaseHookInput

--- a/test/claude_agent/test_hooks.rb
+++ b/test/claude_agent/test_hooks.rb
@@ -200,6 +200,20 @@ class TestClaudeAgentHooks < ActiveSupport::TestCase
     assert_nil input.agent_type
   end
 
+  test "session_start_input_with_model" do
+    input = ClaudeAgent::SessionStartInput.new(
+      source: "startup",
+      model: "claude-sonnet-4-5-20250514"
+    )
+    assert_equal "startup", input.source
+    assert_equal "claude-sonnet-4-5-20250514", input.model
+  end
+
+  test "session_start_input_model_default_nil" do
+    input = ClaudeAgent::SessionStartInput.new(source: "startup")
+    assert_nil input.model
+  end
+
   # --- SessionEndInput ---
 
   test "session_end_input" do

--- a/test/claude_agent/test_options.rb
+++ b/test/claude_agent/test_options.rb
@@ -299,6 +299,31 @@ class TestClaudeAgentOptions < ActiveSupport::TestCase
     assert_includes args, "--agents"
   end
 
+  # --- Agent (main thread) ---
+
+  test "agent_option" do
+    options = ClaudeAgent::Options.new(agent: "my-custom-agent")
+    assert_equal "my-custom-agent", options.agent
+  end
+
+  test "agent_option_default_nil" do
+    options = ClaudeAgent::Options.new
+    assert_nil options.agent
+  end
+
+  test "to_cli_args_with_agent" do
+    options = ClaudeAgent::Options.new(agent: "test-agent")
+    args = options.to_cli_args
+    assert_includes args, "--agent"
+    assert_includes args, "test-agent"
+  end
+
+  test "to_cli_args_without_agent" do
+    options = ClaudeAgent::Options.new
+    args = options.to_cli_args
+    refute_includes args, "--agent"
+  end
+
   # --- Sandbox ---
 
   test "sandbox_option" do


### PR DESCRIPTION
## What
Update SDK specification with latest TypeScript/Python SDK versions and add new features for parity.

## Why
Keep Ruby SDK feature-complete with TypeScript SDK v0.2.9.

## Changes
- Update reference versions: TypeScript v0.2.9, Python v0.1.20
- Add `agent` option for specifying main thread agent name
- Add `model` field to `SessionStartInput` hook input
- Document V2 Session API in README
- Update RBS type signatures
- Bump version to 0.3.0