### PR TITLE
Simplify release script

### DIFF
--- a/.claude/rules/releases.md
+++ b/.claude/rules/releases.md
@@ -12,72 +12,18 @@ Follow [Semantic Versioning 2.0.0](https://semver.org/):
 | **MINOR**    | New features (backward compatible) | `1.0.0` → `1.1.0` |
 | **PATCH**    | Bug fixes (backward compatible)    | `1.0.0` → `1.0.1` |
 
-### Pre-release Versions
-
-For beta/alpha releases, append a pre-release identifier:
-
-```
-1.0.0-alpha.1
-1.0.0-beta.1
-1.0.0-rc.1
-```
-
 ## Changelog Format
 
-Follow [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format:
-
-```markdown
-## [Unreleased]
-
-## [1.2.0] - 2025-03-15
-
-### Added
-- New feature description
-
-### Changed
-- Modified behavior description
-
-### Deprecated
-- Feature scheduled for removal
-
-### Removed
-- Deleted feature description
-
-### Fixed
-- Bug fix description
-
-### Security
-- Security patch description
-```
-
-### Changelog Guidelines
-
-1. **Maintain [Unreleased]** - Always keep an Unreleased section at the top
-2. **Add entries as you work** - Don't wait until release time
-3. **User-focused language** - Write for gem users, not developers
-4. **Link to issues/PRs** - Reference GitHub issues when relevant
-5. **Newest first** - Most recent version at top
-
-### What to Include
-
-| Include | Exclude |
-|---------|---------|
-| API additions/changes | Internal refactors |
-| Bug fixes users might hit | Code style changes |
-| Deprecation notices | Test-only changes |
-| Breaking changes (prominent) | Documentation typos |
-| Security fixes | Dependency updates (minor) |
+Follow [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format. Maintain an `[Unreleased]` section at the top for work in progress.
 
 ## Release Process
 
 ### Prerequisites
 
-Before releasing:
-
 1. All tests pass (`bundle exec rake`)
-2. CHANGELOG.md has entry for new version
-3. No uncommitted changes
-4. On `main` branch (or confirm if not)
+2. CHANGELOG.md has entry for the new version
+3. You have push access to main branch
+4. You have RubyGems publish credentials configured
 
 ### Release Command
 
@@ -94,19 +40,40 @@ bin/release 1.2.0
 
 1. Validates version format (semantic versioning)
 2. Checks CHANGELOG.md has entry for version
-3. Updates `lib/claude_agent/version.rb`
-4. Updates `Gemfile.lock`
-5. Commits with message "Release vX.Y.Z"
-6. Creates annotated tag `vX.Y.Z`
-7. Pushes commit and tag to remote
-8. Builds and publishes gem to RubyGems
+3. Checks tag doesn't already exist
+4. Updates `lib/claude_agent/version.rb`
+5. Updates `Gemfile.lock`
+6. Commits with message "Bump version for X.Y.Z"
+7. Pushes to current branch
+8. Creates and pushes tag `vX.Y.Z`
+9. Builds and publishes gem to RubyGems
+
+### Example Workflow
+
+```bash
+# 1. Ensure tests pass
+bundle exec rake
+
+# 2. Update CHANGELOG.md
+# Move items from [Unreleased] to new version section:
+## [1.2.0] - 2025-03-15
+
+### Added
+- New feature description
+
+# 3. Commit changelog
+git add CHANGELOG.md
+git commit -m "docs: update changelog for 1.2.0"
+git push
+
+# 4. Release
+bin/release 1.2.0
+```
 
 ### Post-Release
 
-After running `bin/release`:
-
-1. Create GitHub release at the new tag
-2. Add `## [Unreleased]` section to CHANGELOG.md
+1. Add `## [Unreleased]` section to CHANGELOG.md if needed
+2. Optionally create a GitHub release at the new tag
 
 ## Version Bumping Guidelines
 
@@ -115,7 +82,6 @@ After running `bin/release`:
 - Removing public methods/classes
 - Changing method signatures (required params)
 - Changing return types
-- Renaming public constants
 - Dropping Ruby version support
 
 ### When to Bump MINOR (Feature)
@@ -130,48 +96,3 @@ After running `bin/release`:
 - Bug fixes
 - Documentation corrections
 - Performance improvements (no API change)
-- Internal refactoring (no API change)
-
-## Example Release Workflow
-
-```bash
-# 1. Ensure tests pass
-bundle exec rake
-
-# 2. Update CHANGELOG.md
-# Add entry under [Unreleased], then rename to version:
-## [1.2.0] - 2025-03-15
-
-### Added
-- New `Client#foo` method for bar functionality
-
-### Fixed
-- Resolved timeout issue in subprocess transport
-
-# 3. Commit changelog
-git add CHANGELOG.md
-git commit -m "docs: update changelog for 1.2.0"
-
-# 4. Release
-bin/release 1.2.0
-
-# 5. Add new Unreleased section
-# Edit CHANGELOG.md to add:
-## [Unreleased]
-
-# 6. Commit
-git add CHANGELOG.md
-git commit -m "docs: add unreleased section"
-git push
-```
-
-## Gem Metadata
-
-The gemspec includes these URIs for RubyGems.org:
-
-```ruby
-spec.metadata["source_code_uri"] = spec.homepage
-spec.metadata["changelog_uri"] = "#{spec.homepage}/blob/main/CHANGELOG.md"
-```
-
-This enables the "Changelog" link on the RubyGems.org gem page.

--- a/bin/release
+++ b/bin/release
@@ -5,136 +5,45 @@ set -euo pipefail
 # Usage: bin/release 1.2.3
 #
 # This script:
-# 1. Validates the version format (semantic versioning)
-# 2. Checks that CHANGELOG.md has an entry for the version
-# 3. Updates lib/claude_agent/version.rb
-# 4. Updates Gemfile.lock
-# 5. Commits, tags, and pushes
-# 6. Builds and publishes the gem
-
-cd "$(dirname "$0")/.."
+# 1. Updates lib/claude_agent/version.rb
+# 2. Updates Gemfile.lock
+# 3. Commits, tags, and pushes to main
+# 4. Builds and publishes the gem to RubyGems
 
 VERSION=${1:-}
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m' # No Color
-
-error() {
-  echo -e "${RED}Error: $1${NC}" >&2
-  exit 1
-}
-
-success() {
-  echo -e "${GREEN}$1${NC}"
-}
-
-warn() {
-  echo -e "${YELLOW}$1${NC}"
-}
-
-# Validate version argument
 if [[ -z "$VERSION" ]]; then
-  error "Usage: bin/release VERSION (e.g., bin/release 1.2.3)"
+  echo "Usage: bin/release VERSION (e.g., bin/release 1.2.3)"
+  exit 1
 fi
 
-# Validate semantic version format
 if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
-  error "Invalid version format. Use semantic versioning: MAJOR.MINOR.PATCH (e.g., 1.2.3 or 1.0.0-beta.1)"
+  echo "Invalid version format. Use semantic versioning (e.g., 1.2.3)"
+  exit 1
 fi
 
-# Check for uncommitted changes
-if ! git diff --quiet HEAD; then
-  error "You have uncommitted changes. Please commit or stash them first."
-fi
-
-# Check that we're on main branch
-CURRENT_BRANCH=$(git branch --show-current)
-if [[ "$CURRENT_BRANCH" != "main" ]]; then
-  warn "Warning: You're on branch '$CURRENT_BRANCH', not 'main'"
-  read -p "Continue anyway? [y/N] " -n 1 -r
-  echo
-  if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-    exit 1
-  fi
-fi
-
-# Check that CHANGELOG.md has an entry for this version
 if ! grep -q "## \[$VERSION\]" CHANGELOG.md; then
-  error "CHANGELOG.md does not have an entry for version $VERSION.
-
-Please add a changelog entry before releasing:
-
-## [$VERSION] - $(date +%Y-%m-%d)
-
-### Added
-- New features...
-
-### Changed
-- Changes...
-
-### Fixed
-- Bug fixes..."
+  echo "CHANGELOG.md does not have an entry for version $VERSION"
+  echo "Please add a changelog entry before releasing"
+  exit 1
 fi
 
-# Check that tag doesn't already exist
 if git tag -l "v$VERSION" | grep -q "v$VERSION"; then
-  error "Tag v$VERSION already exists"
+  echo "Tag v$VERSION already exists"
+  exit 1
 fi
 
-echo "Releasing version $VERSION..."
-echo
+echo "Releasing $VERSION..."
 
-# Update version.rb
-echo "Updating lib/claude_agent/version.rb..."
-cat > lib/claude_agent/version.rb << EOF
-# frozen_string_literal: true
-
-module ClaudeAgent
-  VERSION = "$VERSION"
-end
-EOF
-
-# Update Gemfile.lock
-echo "Updating Gemfile.lock..."
-bundle install --quiet
-
-# Move [Unreleased] section for next development cycle
-# (User should have already added the version entry)
-
-# Stage changes
-git add lib/claude_agent/version.rb Gemfile.lock
-
-# Commit
-echo "Creating commit..."
-git commit -m "Release v$VERSION"
-
-# Create tag
-echo "Creating tag v$VERSION..."
-git tag -a "v$VERSION" -m "Release $VERSION"
-
-# Push
-echo "Pushing to remote..."
-git push origin "$CURRENT_BRANCH"
-git push origin "v$VERSION"
-
-# Build gem
-echo "Building gem..."
+printf "# frozen_string_literal: true\n\nmodule ClaudeAgent\n  VERSION = \"$VERSION\"\nend\n" > lib/claude_agent/version.rb
+bundle
+git add Gemfile.lock lib/claude_agent/version.rb
+git commit -m "Bump version for $VERSION"
+git push
+git tag v$VERSION
+git push --tags
 gem build claude_agent.gemspec
+gem push "claude_agent-$VERSION.gem" --host https://rubygems.org
+rm "claude_agent-$VERSION.gem"
 
-# Publish
-GEM_FILE="claude_agent-$VERSION.gem"
-echo "Publishing $GEM_FILE to RubyGems..."
-gem push "$GEM_FILE"
-
-# Cleanup
-rm -f "$GEM_FILE"
-
-echo
-success "Successfully released claude_agent v$VERSION!"
-echo
-echo "Next steps:"
-echo "  1. Create a GitHub release at: https://github.com/protocollar/claude_agent-ruby/releases/new?tag=v$VERSION"
-echo "  2. Add an [Unreleased] section to CHANGELOG.md for the next version"
+echo "Released claude_agent $VERSION"


### PR DESCRIPTION
## What
Simplifies `bin/release` to match other gems straightforward approach.

## Why
The previous script was designed for a PR-based release workflow, but we want a simpler direct-to-main release process.

## Changes
- Removed branch checking/warnings
- Removed color output helpers
- Streamlined to: validate → update version → bundle → commit → push → tag → publish
- Updated release documentation to match new workflow