### PR TITLE
feat: add view_component-style release workflow

### DIFF
--- a/.claude/rules/releases.md
+++ b/.claude/rules/releases.md
@@ -14,66 +14,84 @@ Follow [Semantic Versioning 2.0.0](https://semver.org/):
 
 ## Changelog Format
 
-Follow [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format. Maintain an `[Unreleased]` section at the top for work in progress.
+Follow [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format. Add changes to the `[Unreleased]` section as you work. The release script will automatically move them to a versioned section.
 
 ## Release Process
 
 ### Prerequisites
 
 1. All tests pass (`bundle exec rake`)
-2. CHANGELOG.md has entry for the new version
-3. You have push access to main branch
-4. You have RubyGems publish credentials configured
+2. Changes documented in `[Unreleased]` section of CHANGELOG.md
+3. You have push access to the repository
+4. Trusted Publishing configured on RubyGems (one-time setup)
 
-### Release Command
+### Step 1: Prepare Release PR
 
-```bash
-bin/release VERSION
-```
-
-Example:
 ```bash
 bin/release 1.2.0
 ```
 
-### What the Script Does
+This will:
+1. Create branch `release-1.2.0`
+2. Update `lib/claude_agent/version.rb`
+3. Update `Gemfile.lock`
+4. Move `[Unreleased]` changelog entries to `[1.2.0]`
+5. Commit, push, and open a PR
 
-1. Validates version format (semantic versioning)
-2. Checks CHANGELOG.md has entry for version
-3. Checks tag doesn't already exist
-4. Updates `lib/claude_agent/version.rb`
-5. Updates `Gemfile.lock`
-6. Commits with message "Bump version for X.Y.Z"
-7. Pushes to current branch
-8. Creates and pushes tag `vX.Y.Z`
-9. Builds and publishes gem to RubyGems
+### Step 2: Review and Merge
 
-### Example Workflow
+- Review the release PR
+- Ensure CI passes
+- Merge to main
+
+### Step 3: Publish
 
 ```bash
-# 1. Ensure tests pass
-bundle exec rake
-
-# 2. Update CHANGELOG.md
-# Move items from [Unreleased] to new version section:
-## [1.2.0] - 2025-03-15
-
-### Added
-- New feature description
-
-# 3. Commit changelog
-git add CHANGELOG.md
-git commit -m "docs: update changelog for 1.2.0"
-git push
-
-# 4. Release
-bin/release 1.2.0
+git checkout main && git pull
+bin/publish 1.2.0
 ```
 
-### Post-Release
+This will:
+1. Verify you're on main with correct version
+2. Create and push tag `v1.2.0`
+3. Create GitHub release
+4. GitHub Actions publishes to RubyGems automatically
 
-1. Add `## [Unreleased]` section to CHANGELOG.md if needed
-2. Optionally create a GitHub release at the new tag
+### Workflow Diagram
+
+```
+bin/release 1.2.0
+       │
+       ├── Creates branch: release-1.2.0
+       ├── Updates version.rb, Gemfile.lock, CHANGELOG.md
+       ├── Commits and pushes
+       └── Opens PR
+              │
+              ▼
+       [Review & merge PR]
+              │
+              ▼
+bin/publish 1.2.0
+       │
+       ├── Creates tag v1.2.0
+       ├── Pushes tag
+       └── Creates GitHub release
+              │
+              ▼
+       [GitHub Actions]
+              │
+              └── Publishes to RubyGems via Trusted Publishing
+```
+
+## Setting Up Trusted Publishing (One-Time)
+
+1. Go to [rubygems.org](https://rubygems.org) → Your gems → claude_agent → Trusted Publishers
+2. Add a new publisher:
+   - Repository owner: `protocollar`
+   - Repository name: `claude_agent-ruby`
+   - Workflow filename: `push_gem.yml`
+   - Environment: `release`
+3. Create a GitHub environment named `release` in your repository settings
 
 ## Version Bumping Guidelines
 

--- a/.github/workflows/push_gem.yml
+++ b/.github/workflows/push_gem.yml
@@ -1,0 +1,33 @@
+name: Push Gem
+
+on:
+  push:
+    tags:
+      - v*
+
+permissions:
+  contents: read
+
+jobs:
+  push:
+    if: github.repository == 'protocollar/claude_agent-ruby'
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      id-token: write
+
+    # Requires "release" environment configured on RubyGems for Trusted Publishing
+    environment: release
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.2"
+          bundler-cache: true
+
+      - name: Publish to RubyGems
+        uses: rubygems/release-gem@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Updated release workflow to use trusted publisher
+
 ## [0.4.2] - 2026-01-18
 
 ### Fixed

--- a/bin/publish
+++ b/bin/publish
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Publish script for claude_agent gem
+# Usage: bin/publish 1.2.3
+#
+# Run this AFTER merging the release PR.
+#
+# This script:
+# 1. Verifies you're on main with the correct version
+# 2. Creates and pushes the version tag
+# 3. Creates a GitHub release
+# 4. GitHub Actions handles publishing to RubyGems via Trusted Publishing
+
+VERSION=${1:-}
+
+if [[ -z "$VERSION" ]]; then
+  echo "Usage: bin/publish VERSION (e.g., bin/publish 1.2.3)"
+  exit 1
+fi
+
+if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+  echo "Invalid version format. Use semantic versioning (e.g., 1.2.3)"
+  exit 1
+fi
+
+# Verify we're on main
+CURRENT_BRANCH=$(git branch --show-current)
+if [[ "$CURRENT_BRANCH" != "main" ]]; then
+  echo "Must be on main branch (currently on $CURRENT_BRANCH)"
+  echo "Run: git checkout main && git pull"
+  exit 1
+fi
+
+# Verify version.rb matches
+CURRENT_VERSION=$(ruby -r ./lib/claude_agent/version.rb -e "puts ClaudeAgent::VERSION")
+if [[ "$CURRENT_VERSION" != "$VERSION" ]]; then
+  echo "Version mismatch: version.rb has $CURRENT_VERSION, expected $VERSION"
+  echo "Make sure the release PR has been merged"
+  exit 1
+fi
+
+if git tag -l "v$VERSION" | grep -q "v$VERSION"; then
+  echo "Tag v$VERSION already exists"
+  exit 1
+fi
+
+echo "Publishing $VERSION..."
+
+# Create and push tag
+git tag "v$VERSION"
+git push origin "v$VERSION"
+
+# Create GitHub release
+gh release create "v$VERSION" --title "v$VERSION" --generate-notes
+
+echo ""
+echo "Tag v$VERSION pushed. GitHub Actions will publish to RubyGems."
+echo "Monitor the workflow at: https://github.com/$(gh repo view --json nameWithOwner -q .nameWithOwner)/actions"

--- a/bin/release
+++ b/bin/release
@@ -1,15 +1,18 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Release script for claude_agent gem
+# Release preparation script for claude_agent gem
 # Usage: bin/release 1.2.3
 #
-# This script:
-# 1. Updates lib/claude_agent/version.rb
-# 2. Updates Gemfile.lock
-# 3. Commits, tags, and pushes to main
-# 4. Creates a GitHub release
-# 5. Builds and publishes the gem to RubyGems
+# This script prepares a release PR:
+# 1. Creates a release branch
+# 2. Updates lib/claude_agent/version.rb
+# 3. Updates Gemfile.lock
+# 4. Moves [Unreleased] changelog entries to new version
+# 5. Commits and pushes the branch
+# 6. Opens a PR
+#
+# After the PR is merged, run: bin/publish 1.2.3
 
 VERSION=${1:-}
 
@@ -23,37 +26,59 @@ if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
   exit 1
 fi
 
-if ! grep -q "## \[$VERSION\]" CHANGELOG.md; then
-  echo "CHANGELOG.md does not have an entry for version $VERSION"
-  echo "Please add a changelog entry before releasing"
-  exit 1
-fi
-
 if git tag -l "v$VERSION" | grep -q "v$VERSION"; then
   echo "Tag v$VERSION already exists"
   exit 1
 fi
 
-# Prompt for OTP upfront
-read -p "Enter RubyGems OTP code: " OTP
+BRANCH="release-$VERSION"
 
-if [[ -z "$OTP" ]]; then
-  echo "OTP is required"
+if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+  echo "Branch $BRANCH already exists"
   exit 1
 fi
 
-echo "Releasing $VERSION..."
+echo "Preparing release $VERSION..."
 
+# Create release branch
+git checkout -b "$BRANCH"
+
+# Update version.rb
 printf "# frozen_string_literal: true\n\nmodule ClaudeAgent\n  VERSION = \"$VERSION\"\nend\n" > lib/claude_agent/version.rb
-bundle install
-git add Gemfile.lock lib/claude_agent/version.rb
-git commit -m "Bump version for $VERSION"
-git push
-git tag v$VERSION
-git push --tags
-gh release create "v$VERSION" --title "v$VERSION" --notes-from-tag
-gem build claude_agent.gemspec
-gem push "claude_agent-$VERSION.gem" --host https://rubygems.org --otp "$OTP"
-rm "claude_agent-$VERSION.gem"
 
-echo "Released claude_agent $VERSION"
+# Update Gemfile.lock
+bundle install
+
+# Update changelog - insert version header after [Unreleased]
+DATE=$(date +%Y-%m-%d)
+sed -i '' "s/## \[Unreleased\]/## [Unreleased]\\
+\\
+## [$VERSION] - $DATE/" CHANGELOG.md
+
+# Commit
+git add lib/claude_agent/version.rb Gemfile.lock CHANGELOG.md
+git commit -m "Release $VERSION"
+
+# Push branch
+git push -u origin "$BRANCH"
+
+# Create PR
+gh pr create --title "Release $VERSION" --body "## Release $VERSION
+
+This PR prepares the release of version $VERSION.
+
+### After merging
+
+Run the following to publish:
+
+\`\`\`bash
+git checkout main && git pull
+bin/publish $VERSION
+\`\`\`
+"
+
+echo ""
+echo "Release PR created. After it's merged, run:"
+echo ""
+echo "  git checkout main && git pull"
+echo "  bin/publish $VERSION"


### PR DESCRIPTION
- Split release into bin/release (prepare PR) and bin/publish (tag & publish)
- Add GitHub Actions workflow for Trusted Publishing
- Update release documentation