### PR TITLE
feat(messages): add missing HookResponseMessage fields for full SDK parity

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -7,6 +7,8 @@ This document provides a comprehensive specification of the Claude Agent SDK, co
 - Python SDK: v0.1.22 from GitHub (commit 6a0140a)
 - Ruby SDK: This repository
 
+**Last Updated:** 2025-01-25
+
 ---
 
 ## Table of Contents
@@ -133,6 +135,34 @@ Messages exchanged between SDK and CLI.
 | `error_max_turns`                     |     ✅      |   ✅    |  ✅   | Max turns exceeded                 |
 | `error_max_budget_usd`                |     ✅      |   ✅    |  ✅   | Budget exceeded                    |
 | `error_max_structured_output_retries` |     ✅      |   ❌    |  ✅   | Structured output retries exceeded |
+
+#### HookResponseMessage Fields
+
+| Field        | TypeScript | Python | Ruby | Notes                                    |
+|--------------|:----------:|:------:|:----:|------------------------------------------|
+| `uuid`       |     ✅      |   ❌    |  ✅   | Message UUID                             |
+| `session_id` |     ✅      |   ❌    |  ✅   | Session ID                               |
+| `hook_id`    |     ✅      |   ❌    |  ✅   | Unique hook execution ID                 |
+| `hook_name`  |     ✅      |   ❌    |  ✅   | Hook name                                |
+| `hook_event` |     ✅      |   ❌    |  ✅   | Event type (PreToolUse, PostToolUse...)  |
+| `output`     |     ✅      |   ❌    |  ✅   | Combined output string                   |
+| `stdout`     |     ✅      |   ❌    |  ✅   | Standard output                          |
+| `stderr`     |     ✅      |   ❌    |  ✅   | Standard error                           |
+| `exit_code`  |     ✅      |   ❌    |  ✅   | Hook process exit code                   |
+| `outcome`    |     ✅      |   ❌    |  ✅   | 'success' / 'error' / 'cancelled'        |
+
+#### HookProgressMessage Fields
+
+| Field        | TypeScript | Python | Ruby | Notes                                    |
+|--------------|:----------:|:------:|:----:|------------------------------------------|
+| `uuid`       |     ✅      |   ❌    |  ✅   | Message UUID                             |
+| `session_id` |     ✅      |   ❌    |  ✅   | Session ID                               |
+| `hook_id`    |     ✅      |   ❌    |  ✅   | Unique hook execution ID                 |
+| `hook_name`  |     ✅      |   ❌    |  ✅   | Hook name                                |
+| `hook_event` |     ✅      |   ❌    |  ✅   | Event type                               |
+| `output`     |     ✅      |   ❌    |  ✅   | Combined output so far                   |
+| `stdout`     |     ✅      |   ❌    |  ✅   | Standard output so far                   |
+| `stderr`     |     ✅      |   ❌    |  ✅   | Standard error so far                    |
 
 ---
 

--- a/lib/claude_agent/message_parser.rb
+++ b/lib/claude_agent/message_parser.rb
@@ -249,11 +249,14 @@ module ClaudeAgent
       HookResponseMessage.new(
         uuid: raw["uuid"] || "",
         session_id: fetch_dual(raw, :session_id, ""),
+        hook_id: fetch_dual(raw, :hook_id),
         hook_name: fetch_dual(raw, :hook_name, ""),
         hook_event: fetch_dual(raw, :hook_event, ""),
         stdout: raw["stdout"] || "",
         stderr: raw["stderr"] || "",
-        exit_code: fetch_dual(raw, :exit_code)
+        output: raw["output"] || "",
+        exit_code: fetch_dual(raw, :exit_code),
+        outcome: raw["outcome"]
       )
     end
 

--- a/lib/claude_agent/messages.rb
+++ b/lib/claude_agent/messages.rb
@@ -337,36 +337,71 @@ module ClaudeAgent
   #   msg = HookResponseMessage.new(
   #     uuid: "msg-123",
   #     session_id: "session-abc",
+  #     hook_id: "hook-456",
   #     hook_name: "my-hook",
   #     hook_event: "PreToolUse",
   #     stdout: "Hook output",
   #     stderr: "",
-  #     exit_code: 0
+  #     output: "Combined output",
+  #     exit_code: 0,
+  #     outcome: "success"
   #   )
+  #   msg.success?    # => true
+  #   msg.error?      # => false
+  #   msg.cancelled?  # => false
+  #
+  # Outcome values:
+  # - "success" - Hook completed successfully
+  # - "error" - Hook encountered an error
+  # - "cancelled" - Hook was cancelled
   #
   HookResponseMessage = Data.define(
     :uuid,
     :session_id,
+    :hook_id,
     :hook_name,
     :hook_event,
     :stdout,
     :stderr,
-    :exit_code
+    :output,
+    :exit_code,
+    :outcome
   ) do
     def initialize(
       uuid:,
       session_id:,
+      hook_id: nil,
       hook_name:,
       hook_event:,
       stdout: "",
       stderr: "",
-      exit_code: nil
+      output: "",
+      exit_code: nil,
+      outcome: nil
     )
       super
     end
 
     def type
       :hook_response
+    end
+
+    # Check if hook completed successfully
+    # @return [Boolean]
+    def success?
+      outcome == "success"
+    end
+
+    # Check if hook encountered an error
+    # @return [Boolean]
+    def error?
+      outcome == "error"
+    end
+
+    # Check if hook was cancelled
+    # @return [Boolean]
+    def cancelled?
+      outcome == "cancelled"
     end
   end
 

--- a/sig/claude_agent.rbs
+++ b/sig/claude_agent.rbs
@@ -534,14 +534,20 @@ module ClaudeAgent
   class HookResponseMessage
     attr_reader uuid: String
     attr_reader session_id: String
+    attr_reader hook_id: String?
     attr_reader hook_name: String
     attr_reader hook_event: String
     attr_reader stdout: String
     attr_reader stderr: String
+    attr_reader output: String
     attr_reader exit_code: Integer?
+    attr_reader outcome: String?
 
-    def initialize: (uuid: String, session_id: String, hook_name: String, hook_event: String, ?stdout: String, ?stderr: String, ?exit_code: Integer?) -> void
+    def initialize: (uuid: String, session_id: String, ?hook_id: String?, hook_name: String, hook_event: String, ?stdout: String, ?stderr: String, ?output: String, ?exit_code: Integer?, ?outcome: String?) -> void
     def type: () -> :hook_response
+    def success?: () -> bool
+    def error?: () -> bool
+    def cancelled?: () -> bool
   end
 
   # Auth status message (TypeScript SDK parity)

--- a/test/claude_agent/test_message_parser.rb
+++ b/test/claude_agent/test_message_parser.rb
@@ -442,23 +442,30 @@ class TestClaudeAgentMessageParser < ActiveSupport::TestCase
       "subtype" => "hook_response",
       "uuid" => "msg-123",
       "session_id" => "sess-abc",
+      "hook_id" => "hook-456",
       "hook_name" => "my-hook",
       "hook_event" => "PreToolUse",
       "stdout" => "Hook output",
       "stderr" => "Warning message",
-      "exit_code" => 0
+      "output" => "Combined output",
+      "exit_code" => 0,
+      "outcome" => "success"
     }
     msg = @parser.parse(raw)
 
     assert_instance_of ClaudeAgent::HookResponseMessage, msg
     assert_equal "msg-123", msg.uuid
     assert_equal "sess-abc", msg.session_id
+    assert_equal "hook-456", msg.hook_id
     assert_equal "my-hook", msg.hook_name
     assert_equal "PreToolUse", msg.hook_event
     assert_equal "Hook output", msg.stdout
     assert_equal "Warning message", msg.stderr
+    assert_equal "Combined output", msg.output
     assert_equal 0, msg.exit_code
+    assert_equal "success", msg.outcome
     assert_equal :hook_response, msg.type
+    assert msg.success?
   end
 
   test "parse_hook_response_message_camel_case" do
@@ -467,18 +474,43 @@ class TestClaudeAgentMessageParser < ActiveSupport::TestCase
       "subtype" => "hook_response",
       "uuid" => "msg-456",
       "sessionId" => "sess-xyz",
+      "hookId" => "hook-789",
       "hookName" => "format-hook",
       "hookEvent" => "PostToolUse",
       "stdout" => "Formatted",
       "stderr" => "",
-      "exitCode" => 1
+      "output" => "Formatted",
+      "exitCode" => 1,
+      "outcome" => "error"
     }
     msg = @parser.parse(raw)
 
     assert_equal "sess-xyz", msg.session_id
+    assert_equal "hook-789", msg.hook_id
     assert_equal "format-hook", msg.hook_name
     assert_equal "PostToolUse", msg.hook_event
     assert_equal 1, msg.exit_code
+    assert_equal "error", msg.outcome
+    assert msg.error?
+  end
+
+  test "parse_hook_response_message_defaults" do
+    raw = {
+      "type" => "system",
+      "subtype" => "hook_response",
+      "uuid" => "msg-123",
+      "session_id" => "sess-abc",
+      "hook_name" => "my-hook",
+      "hook_event" => "PreToolUse"
+    }
+    msg = @parser.parse(raw)
+
+    assert_nil msg.hook_id
+    assert_equal "", msg.stdout
+    assert_equal "", msg.stderr
+    assert_equal "", msg.output
+    assert_nil msg.exit_code
+    assert_nil msg.outcome
   end
 
   # --- AuthStatusMessage parsing ---

--- a/test/claude_agent/test_messages.rb
+++ b/test/claude_agent/test_messages.rb
@@ -251,19 +251,25 @@ class TestClaudeAgentMessages < ActiveSupport::TestCase
     msg = ClaudeAgent::HookResponseMessage.new(
       uuid: "msg-123",
       session_id: "session-abc",
+      hook_id: "hook-456",
       hook_name: "my-hook",
       hook_event: "PreToolUse",
       stdout: "Hook output",
       stderr: "",
-      exit_code: 0
+      output: "Combined output",
+      exit_code: 0,
+      outcome: "success"
     )
     assert_equal "msg-123", msg.uuid
     assert_equal "session-abc", msg.session_id
+    assert_equal "hook-456", msg.hook_id
     assert_equal "my-hook", msg.hook_name
     assert_equal "PreToolUse", msg.hook_event
     assert_equal "Hook output", msg.stdout
     assert_equal "", msg.stderr
+    assert_equal "Combined output", msg.output
     assert_equal 0, msg.exit_code
+    assert_equal "success", msg.outcome
     assert_equal :hook_response, msg.type
   end
 
@@ -274,9 +280,51 @@ class TestClaudeAgentMessages < ActiveSupport::TestCase
       hook_name: "my-hook",
       hook_event: "PreToolUse"
     )
+    assert_nil msg.hook_id
     assert_equal "", msg.stdout
     assert_equal "", msg.stderr
+    assert_equal "", msg.output
     assert_nil msg.exit_code
+    assert_nil msg.outcome
+  end
+
+  test "hook_response_message_success?" do
+    msg = ClaudeAgent::HookResponseMessage.new(
+      uuid: "msg-123",
+      session_id: "session-abc",
+      hook_name: "my-hook",
+      hook_event: "PreToolUse",
+      outcome: "success"
+    )
+    assert msg.success?
+    refute msg.error?
+    refute msg.cancelled?
+  end
+
+  test "hook_response_message_error?" do
+    msg = ClaudeAgent::HookResponseMessage.new(
+      uuid: "msg-123",
+      session_id: "session-abc",
+      hook_name: "my-hook",
+      hook_event: "PreToolUse",
+      outcome: "error"
+    )
+    refute msg.success?
+    assert msg.error?
+    refute msg.cancelled?
+  end
+
+  test "hook_response_message_cancelled?" do
+    msg = ClaudeAgent::HookResponseMessage.new(
+      uuid: "msg-123",
+      session_id: "session-abc",
+      hook_name: "my-hook",
+      hook_event: "PreToolUse",
+      outcome: "cancelled"
+    )
+    refute msg.success?
+    refute msg.error?
+    assert msg.cancelled?
   end
 
   test "hook_response_message_in_types_constant" do


### PR DESCRIPTION
## What
Add `hook_id`, `output`, and `outcome` fields to `HookResponseMessage` to achieve complete TypeScript SDK parity.

## Why
The Ruby SDK was missing three fields from `HookResponseMessage` that exist in the TypeScript SDK. This completes feature parity.

## How
- Added three new fields to `HookResponseMessage`: `hook_id`, `output`, `outcome`
- Added helper methods: `success?`, `error?`, `cancelled?`
- Updated `MessageParser` to parse the new fields
- Updated RBS type signatures
- Updated SPEC.md to reflect complete parity