### PR TITLE
feat(messages): add FilesPersistedEvent for full SDK parity with TS v0.2.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `FilesPersistedEvent` message type for file persistence confirmation (TypeScript SDK v0.2.25 parity)
+- `claudeai-proxy` MCP server type support via Hash-based config passthrough
+
+### Changed
+- Updated SPEC.md to reference TypeScript SDK v0.2.25 and Python SDK v0.1.25
+
 ## [0.5.0] - 2026-01-25
 
 ### Added

--- a/SPEC.md
+++ b/SPEC.md
@@ -3,11 +3,11 @@
 This document provides a comprehensive specification of the Claude Agent SDK, comparing feature parity across the official TypeScript and Python SDKs with this Ruby implementation.
 
 **Reference Versions:**
-- TypeScript SDK: v0.2.19 (npm package)
-- Python SDK: v0.1.22 from GitHub (commit 6a0140a)
+- TypeScript SDK: v0.2.25 (npm package)
+- Python SDK: v0.1.25 from GitHub (commit 1bf665c)
 - Ruby SDK: This repository
 
-**Last Updated:** 2025-01-25
+**Last Updated:** 2026-01-30
 
 ---
 
@@ -65,7 +65,7 @@ Configuration options for SDK queries and clients.
 | `additionalDirectories`           |     ✅      |   ✅    |  ✅   | Extra allowed directories                                    |
 | `env`                             |     ✅      |   ✅    |  ✅   | Environment variables                                        |
 | `sandbox`                         |     ✅      |   ✅    |  ✅   | Sandbox settings                                             |
-| `settings`                        |     ✅      |   ❌    |  ✅   | Settings file path or JSON string (e.g., plansDirectory)     |
+| `settings`                        |     ✅      |   ✅    |  ✅   | Settings file path or JSON string (e.g., plansDirectory)     |
 | `settingSources`                  |     ✅      |   ✅    |  ✅   | Which settings to load                                       |
 | `plugins`                         |     ✅      |   ✅    |  ✅   | Plugin configurations                                        |
 | `betas`                           |     ✅      |   ✅    |  ✅   | Beta features (e.g., context-1m-2025-08-07)                  |
@@ -104,6 +104,7 @@ Messages exchanged between SDK and CLI.
 | `AuthStatusMessage`       |     ✅      |   ❌    |  ✅   | Authentication status              |
 | `TaskNotificationMessage` |     ✅      |   ❌    |  ✅   | Background task completion         |
 | `ToolUseSummaryMessage`   |     ✅      |   ❌    |  ✅   | Summary of tool use (collapsed)    |
+| `FilesPersistedEvent`     |     ✅      |   ❌    |  ✅   | File persistence confirmation      |
 
 ### Message Fields
 
@@ -212,12 +213,12 @@ Bidirectional control protocol for SDK-CLI communication.
 | `can_use_tool`            |     ✅      |   ✅    |  ✅   | Permission callback               |
 | `hook_callback`           |     ✅      |   ✅    |  ✅   | Execute hook callback             |
 | `set_permission_mode`     |     ✅      |   ✅    |  ✅   | Change permission mode            |
-| `set_model`               |     ✅      |   ❌    |  ✅   | Change model                      |
+| `set_model`               |     ✅      |   ✅    |  ✅   | Change model                      |
 | `set_max_thinking_tokens` |     ✅      |   ❌    |  ✅   | Change thinking tokens limit      |
 | `rewind_files`            |     ✅      |   ✅    |  ✅   | Rewind file checkpoints           |
 | `mcp_message`             |     ✅      |   ✅    |  ✅   | Route MCP message                 |
 | `mcp_set_servers`         |     ✅      |   ❌    |  ✅   | Dynamically set MCP servers       |
-| `mcp_status`              |     ✅      |   ❌    |  ✅   | Get MCP server status             |
+| `mcp_status`              |     ✅      |   ✅    |  ✅   | Get MCP server status             |
 | `mcp_reconnect`           |     ✅      |   ❌    |  ✅   | Reconnect to MCP server           |
 | `mcp_toggle`              |     ✅      |   ❌    |  ✅   | Enable/disable MCP server         |
 | `supported_commands`      |     ✅      |   ❌    |  ✅   | Get available slash commands      |
@@ -247,7 +248,7 @@ Event hooks for intercepting and modifying SDK behavior.
 |----------------------|:----------:|:------:|:----:|---------------------------|
 | `PreToolUse`         |     ✅      |   ✅    |  ✅   | Before tool execution     |
 | `PostToolUse`        |     ✅      |   ✅    |  ✅   | After tool execution      |
-| `PostToolUseFailure` |     ✅      |   ❌    |  ✅   | After tool failure        |
+| `PostToolUseFailure` |     ✅      |   ✅    |  ✅   | After tool failure        |
 | `Notification`       |     ✅      |   ❌    |  ✅   | System notifications      |
 | `UserPromptSubmit`   |     ✅      |   ✅    |  ✅   | User message submitted    |
 | `SessionStart`       |     ✅      |   ❌    |  ✅   | Session starts            |
@@ -265,7 +266,7 @@ Event hooks for intercepting and modifying SDK behavior.
 |-------------------------------|:----------:|:------:|:----:|
 | `PreToolUseHookInput`         |     ✅      |   ✅    |  ✅   |
 | `PostToolUseHookInput`        |     ✅      |   ✅    |  ✅   |
-| `PostToolUseFailureHookInput` |     ✅      |   ❌    |  ✅   |
+| `PostToolUseFailureHookInput` |     ✅      |   ✅    |  ✅   |
 | `NotificationHookInput`       |     ✅      |   ❌    |  ✅   |
 | `UserPromptSubmitHookInput`   |     ✅      |   ✅    |  ✅   |
 | `SessionStartHookInput`       |     ✅      |   ❌    |  ✅   |
@@ -300,7 +301,7 @@ Event-specific fields returned via `hookSpecificOutput`:
 | Field                      | TypeScript | Python | Ruby | Notes                              |
 |----------------------------|:----------:|:------:|:----:|------------------------------------|
 | `permissionDecision`       |     ✅      |   ✅    |  ✅   | `allow`, `deny`, or `ask`          |
-| `permissionDecisionReason` |     ✅      |   ❌    |  ✅   | Reason for permission decision     |
+| `permissionDecisionReason` |     ✅      |   ✅    |  ✅   | Reason for permission decision     |
 | `updatedInput`             |     ✅      |   ✅    |  ✅   | Modified tool input                |
 | `additionalContext`        |     ✅      |   ❌    |  ✅   | Context string returned to model   |
 
@@ -315,7 +316,7 @@ Event-specific fields returned via `hookSpecificOutput`:
 
 | Field               | TypeScript | Python | Ruby | Notes                            |
 |---------------------|:----------:|:------:|:----:|----------------------------------|
-| `additionalContext` |     ✅      |   ❌    |  ✅   | Context string returned to model |
+| `additionalContext` |     ✅      |   ✅    |  ✅   | Context string returned to model |
 
 #### SessionStartHookSpecificOutput
 
@@ -436,12 +437,13 @@ Model Context Protocol server support.
 
 ### MCP Server Types
 
-| Type    | TypeScript | Python | Ruby | Notes                 |
-|---------|:----------:|:------:|:----:|-----------------------|
-| `stdio` |     ✅      |   ✅    |  ✅   | Subprocess with stdio |
-| `sse`   |     ✅      |   ✅    |  ✅   | Server-sent events    |
-| `http`  |     ✅      |   ✅    |  ✅   | HTTP transport        |
-| `sdk`   |     ✅      |   ✅    |  ✅   | In-process SDK server |
+| Type             | TypeScript | Python | Ruby | Notes                            |
+|------------------|:----------:|:------:|:----:|----------------------------------|
+| `stdio`          |     ✅      |   ✅    |  ✅   | Subprocess with stdio            |
+| `sse`            |     ✅      |   ✅    |  ✅   | Server-sent events               |
+| `http`           |     ✅      |   ✅    |  ✅   | HTTP transport                   |
+| `sdk`            |     ✅      |   ✅    |  ✅   | In-process SDK server            |
+| `claudeai-proxy` |     ✅      |   ❌    |  ✅   | Claude.ai proxy server (managed) |
 
 ### MCP Server Config Fields
 
@@ -595,41 +597,41 @@ Public API surface for SDK clients.
 | One-shot query function | ✅ `query()` | ✅ `query()` | ✅ `ClaudeAgent.query()` | Simple prompts     |
 | Returns async generator |      ✅      |      ✅      |     ✅ (Enumerator)      | Streaming messages |
 
-### Query Control Methods (TypeScript)
+### Query Control Methods
 
 | Method                   | TypeScript | Python | Ruby | Notes                  |
 |--------------------------|:----------:|:------:|:----:|------------------------|
-| `interrupt()`            |     ✅      |   ❌    |  ✅   | Interrupt execution    |
-| `setPermissionMode()`    |     ✅      |   ❌    |  ✅   | Change permission mode |
-| `setModel()`             |     ✅      |   ❌    |  ✅   | Change model           |
+| `interrupt()`            |     ✅      |   ✅    |  ✅   | Interrupt execution    |
+| `setPermissionMode()`    |     ✅      |   ✅    |  ✅   | Change permission mode |
+| `setModel()`             |     ✅      |   ✅    |  ✅   | Change model           |
 | `setMaxThinkingTokens()` |     ✅      |   ❌    |  ✅   | Set thinking limit     |
 | `supportedCommands()`    |     ✅      |   ❌    |  ✅   | Get slash commands     |
 | `supportedModels()`      |     ✅      |   ❌    |  ✅   | Get available models   |
-| `mcpServerStatus()`      |     ✅      |   ❌    |  ✅   | Get MCP status         |
+| `mcpServerStatus()`      |     ✅      |   ✅    |  ✅   | Get MCP status         |
 | `accountInfo()`          |     ✅      |   ❌    |  ✅   | Get account info       |
 | `rewindFiles()`          |     ✅      |   ✅    |  ✅   | Rewind file changes    |
 | `setMcpServers()`        |     ✅      |   ❌    |  ✅   | Dynamic MCP servers    |
-| `streamInput()`          |     ✅      |   ❌    |  ✅   | Stream user input      |
-| `close()`                |     ✅      |   ❌    |  ✅   | Close query/session    |
+| `streamInput()`          |     ✅      |   ✅    |  ✅   | Stream user input      |
+| `close()`                |     ✅      |   ✅    |  ✅   | Close query/session    |
 
 ### Client Class
 
-| Feature              | TypeScript |       Python        |          Ruby           | Notes                          |
-|----------------------|:----------:|:-------------------:|:-----------------------:|--------------------------------|
-| Multi-turn client    |     ❌      | ✅ `ClaudeSDKClient` | ✅ `ClaudeAgent::Client` | Interactive sessions           |
-| `connect()`          |    N/A     |          ✅          |            ✅            | Start session                  |
-| `disconnect()`       |    N/A     |          ✅          |            ✅            | End session                    |
-| `send_message()`     |    N/A     |          ✅          |            ✅            | Send user message              |
-| `receive_response()` |    N/A     |          ✅          |            ✅            | Receive until result           |
-| `stream_input()`     |    N/A     |          ❌          |            ✅            | Stream input messages          |
-| `abort!()`           |    N/A     |          ❌          |            ✅            | Abort operations               |
-| Control methods      |    N/A     |       Partial       |            ✅            | All TypeScript control methods |
+| Feature              | TypeScript |       Python        |          Ruby           | Notes                                                                            |
+|----------------------|:----------:|:-------------------:|:-----------------------:|----------------------------------------------------------------------------------|
+| Multi-turn client    |     ❌      | ✅ `ClaudeSDKClient` | ✅ `ClaudeAgent::Client` | Interactive sessions                                                             |
+| `connect()`          |    N/A     |          ✅          |            ✅            | Start session                                                                    |
+| `disconnect()`       |    N/A     |          ✅          |            ✅            | End session                                                                      |
+| `send_message()`     |    N/A     |          ✅          |            ✅            | Send user message                                                                |
+| `receive_response()` |    N/A     |          ✅          |            ✅            | Receive until result                                                             |
+| `stream_input()`     |    N/A     |          ❌          |            ✅            | Stream input messages                                                            |
+| `abort!()`           |    N/A     |          ❌          |            ✅            | Abort operations                                                                 |
+| Control methods      |    N/A     |       Partial       |            ✅            | interrupt, setPermissionMode, setModel, rewindFiles (Python); all methods (Ruby) |
 
 ### Transport
 
 | Feature               | TypeScript | Python | Ruby | Notes                    |
 |-----------------------|:----------:|:------:|:----:|--------------------------|
-| `Transport` interface |     ✅      |   ❌    |  ✅   | Transport abstraction    |
+| `Transport` interface |     ✅      |   ✅    |  ✅   | Transport abstraction    |
 | Process transport     |     ✅      |   ✅    |  ✅   | Subprocess communication |
 | Custom spawn          |     ✅      |   ❌    |  ✅   | VM/container support     |
 
@@ -659,21 +661,32 @@ Public API surface for SDK clients.
 - v0.2.12+ adds `user` option to SDKSessionOptions
 - v0.2.19 adds `mcp_reconnect` and `mcp_toggle` control requests
 - v0.2.19 adds `HookStartedMessage`, `HookProgressMessage`, and `ToolUseSummaryMessage`
+- v0.2.25 adds `SDKFilesPersistedEvent` message type for file persistence confirmation
+- v0.2.25 adds `McpClaudeAIProxyServerConfig` (`claudeai-proxy` type) for managed proxy servers
 
 ### Python SDK
-- Full source available (v0.1.22)
-- Fewer control protocol features than TypeScript
-- Does not support SessionStart/SessionEnd/Notification hooks due to setup limitations
+- Full source available (v0.1.25)
+- Now has `Transport` abstract class and several query control methods
+- Supports `interrupt()`, `set_permission_mode()`, `set_model()`, `rewind_files()`, `stream_input()`, `close()`, `get_mcp_status()` in query
+- Client also supports `interrupt()`, `set_permission_mode()`, `set_model()`, `rewind_files()`
+- Does not support SessionStart/SessionEnd/Notification/SubagentStart/PermissionRequest/Setup hooks
 - Missing several permission modes (delegate, dontAsk)
+- Missing `allowDangerouslySkipPermissions`, `persistSession`, `resumeSessionAt`, `strictMcpConfig`
+- Missing `init`/`initOnly`/`maintenance` Setup hook options
 - `excludedCommands` in sandbox now supported
-- `tool_use_id` now included in PreToolUseHookInput
-- `additionalContext` now supported in UserPromptSubmitHookSpecificOutput
+- v0.1.25 adds `PostToolUseFailure` hook event support
+- v0.1.25 adds `permissionDecisionReason` to `PreToolUseHookSpecificOutput`
+- `additionalContext` supported in `UserPromptSubmitHookSpecificOutput`
+- `PreToolUseHookInput` does not include `tool_use_id` (unlike TypeScript)
+- `ToolPermissionContext` missing `blockedPath`, `decisionReason`, `toolUseID`, `agentID`
 
 ### Ruby SDK (This Repository)
-- Complete TypeScript SDK feature parity
+- Full TypeScript SDK feature parity
 - Ruby-idiomatic patterns (Data.define, snake_case)
 - Complete control protocol support
 - Dedicated Client class for multi-turn conversations
 - Full hook event support including all 13 events
 - Full V2 Session API support (unstable)
 - `executable`/`executableArgs` marked N/A (JS runtime options not applicable to Ruby)
+- Added: `FilesPersistedEvent` message type (new in TS v0.2.25)
+- `claudeai-proxy` MCP server type handled transparently via Hash-based config passthrough (new in TS v0.2.25)

--- a/lib/claude_agent/message_parser.rb
+++ b/lib/claude_agent/message_parser.rb
@@ -11,7 +11,7 @@ module ClaudeAgent
     # Parse a raw message hash into a typed message object
     #
     # @param raw [Hash] Raw message from CLI
-    # @return [UserMessage, UserMessageReplay, AssistantMessage, SystemMessage, ResultMessage, StreamEvent, CompactBoundaryMessage, StatusMessage, ToolProgressMessage, HookResponseMessage, AuthStatusMessage, TaskNotificationMessage, HookStartedMessage, HookProgressMessage, ToolUseSummaryMessage]
+    # @return [UserMessage, UserMessageReplay, AssistantMessage, SystemMessage, ResultMessage, StreamEvent, CompactBoundaryMessage, StatusMessage, ToolProgressMessage, HookResponseMessage, AuthStatusMessage, TaskNotificationMessage, HookStartedMessage, HookProgressMessage, ToolUseSummaryMessage, FilesPersistedEvent]
     # @raise [MessageParseError] If message cannot be parsed
     def parse(raw)
       type = raw["type"]
@@ -36,6 +36,8 @@ module ClaudeAgent
           parse_hook_started_message(raw)
         when "hook_progress"
           parse_hook_progress_message(raw)
+        when "files_persisted"
+          parse_files_persisted_event(raw)
         else
           parse_system_message(raw)
         end
@@ -310,6 +312,16 @@ module ClaudeAgent
         session_id: fetch_dual(raw, :session_id, ""),
         summary: raw["summary"] || "",
         preceding_tool_use_ids: fetch_dual(raw, :preceding_tool_use_ids, [])
+      )
+    end
+
+    def parse_files_persisted_event(raw)
+      FilesPersistedEvent.new(
+        uuid: raw["uuid"] || "",
+        session_id: fetch_dual(raw, :session_id, ""),
+        files: raw["files"] || [],
+        failed: raw["failed"] || [],
+        processed_at: fetch_dual(raw, :processed_at)
       )
     end
   end

--- a/lib/claude_agent/messages.rb
+++ b/lib/claude_agent/messages.rb
@@ -614,6 +614,43 @@ module ClaudeAgent
     end
   end
 
+  # Files persisted event (TypeScript SDK v0.2.25 parity)
+  #
+  # Sent when files are persisted to storage during a session.
+  # Contains lists of successfully persisted files and any failures.
+  #
+  # @example
+  #   msg = FilesPersistedEvent.new(
+  #     uuid: "msg-123",
+  #     session_id: "session-abc",
+  #     files: [{ "filename" => "test.rb", "file_id" => "file-456" }],
+  #     failed: [],
+  #     processed_at: "2026-01-30T12:00:00Z"
+  #   )
+  #   msg.files.first["filename"]  # => "test.rb"
+  #
+  FilesPersistedEvent = Data.define(
+    :uuid,
+    :session_id,
+    :files,
+    :failed,
+    :processed_at
+  ) do
+    def initialize(
+      uuid:,
+      session_id:,
+      files: [],
+      failed: [],
+      processed_at: nil
+    )
+      super
+    end
+
+    def type
+      :files_persisted
+    end
+  end
+
   # All message types
   MESSAGE_TYPES = [
     UserMessage,
@@ -630,6 +667,7 @@ module ClaudeAgent
     TaskNotificationMessage,
     HookStartedMessage,
     HookProgressMessage,
-    ToolUseSummaryMessage
+    ToolUseSummaryMessage,
+    FilesPersistedEvent
   ].freeze
 end

--- a/sig/claude_agent.rbs
+++ b/sig/claude_agent.rbs
@@ -393,7 +393,7 @@ module ClaudeAgent
   CONTENT_BLOCK_TYPES: Array[Class]
 
   # Message types
-  type message = UserMessage | UserMessageReplay | AssistantMessage | SystemMessage | ResultMessage | StreamEvent | CompactBoundaryMessage | StatusMessage | ToolProgressMessage | HookResponseMessage | AuthStatusMessage | TaskNotificationMessage | HookStartedMessage | HookProgressMessage | ToolUseSummaryMessage
+  type message = UserMessage | UserMessageReplay | AssistantMessage | SystemMessage | ResultMessage | StreamEvent | CompactBoundaryMessage | StatusMessage | ToolProgressMessage | HookResponseMessage | AuthStatusMessage | TaskNotificationMessage | HookStartedMessage | HookProgressMessage | ToolUseSummaryMessage | FilesPersistedEvent
 
   MESSAGE_TYPES: Array[Class]
 
@@ -614,6 +614,18 @@ module ClaudeAgent
 
     def initialize: (uuid: String, session_id: String, summary: String, ?preceding_tool_use_ids: Array[String]) -> void
     def type: () -> :tool_use_summary
+  end
+
+  # Files persisted event (TypeScript SDK v0.2.25 parity)
+  class FilesPersistedEvent
+    attr_reader uuid: String
+    attr_reader session_id: String
+    attr_reader files: Array[Hash[String, String]]
+    attr_reader failed: Array[Hash[String, String]]
+    attr_reader processed_at: String?
+
+    def initialize: (uuid: String, session_id: String, ?files: Array[Hash[String, String]], ?failed: Array[Hash[String, String]], ?processed_at: String?) -> void
+    def type: () -> :files_persisted
   end
 
   # Message parser

--- a/test/claude_agent/test_message_parser.rb
+++ b/test/claude_agent/test_message_parser.rb
@@ -768,4 +768,64 @@ class TestClaudeAgentMessageParser < ActiveSupport::TestCase
 
     assert_equal [], msg.preceding_tool_use_ids
   end
+
+  # --- FilesPersistedEvent parsing ---
+
+  test "parse_files_persisted_event" do
+    raw = {
+      "type" => "system",
+      "subtype" => "files_persisted",
+      "uuid" => "msg-123",
+      "session_id" => "sess-abc",
+      "files" => [
+        { "filename" => "test.rb", "file_id" => "file-456" }
+      ],
+      "failed" => [
+        { "filename" => "bad.rb", "error" => "Permission denied" }
+      ],
+      "processed_at" => "2026-01-30T12:00:00Z"
+    }
+    msg = @parser.parse(raw)
+
+    assert_instance_of ClaudeAgent::FilesPersistedEvent, msg
+    assert_equal "msg-123", msg.uuid
+    assert_equal "sess-abc", msg.session_id
+    assert_equal 1, msg.files.size
+    assert_equal "test.rb", msg.files.first["filename"]
+    assert_equal "file-456", msg.files.first["file_id"]
+    assert_equal 1, msg.failed.size
+    assert_equal "bad.rb", msg.failed.first["filename"]
+    assert_equal "2026-01-30T12:00:00Z", msg.processed_at
+    assert_equal :files_persisted, msg.type
+  end
+
+  test "parse_files_persisted_event_camel_case" do
+    raw = {
+      "type" => "system",
+      "subtype" => "files_persisted",
+      "uuid" => "msg-456",
+      "sessionId" => "sess-xyz",
+      "files" => [],
+      "failed" => [],
+      "processedAt" => "2026-01-30T13:00:00Z"
+    }
+    msg = @parser.parse(raw)
+
+    assert_equal "sess-xyz", msg.session_id
+    assert_equal "2026-01-30T13:00:00Z", msg.processed_at
+  end
+
+  test "parse_files_persisted_event_defaults" do
+    raw = {
+      "type" => "system",
+      "subtype" => "files_persisted",
+      "uuid" => "msg-123",
+      "session_id" => "sess-abc"
+    }
+    msg = @parser.parse(raw)
+
+    assert_equal [], msg.files
+    assert_equal [], msg.failed
+    assert_nil msg.processed_at
+  end
 end

--- a/test/claude_agent/test_messages.rb
+++ b/test/claude_agent/test_messages.rb
@@ -522,4 +522,38 @@ class TestClaudeAgentMessages < ActiveSupport::TestCase
   test "tool_use_summary_message_in_types_constant" do
     assert_includes ClaudeAgent::MESSAGE_TYPES, ClaudeAgent::ToolUseSummaryMessage
   end
+
+  # --- FilesPersistedEvent ---
+
+  test "files_persisted_event" do
+    files = [ { "filename" => "test.rb", "file_id" => "file-456" } ]
+    failed = [ { "filename" => "bad.rb", "error" => "Permission denied" } ]
+    msg = ClaudeAgent::FilesPersistedEvent.new(
+      uuid: "msg-123",
+      session_id: "session-abc",
+      files: files,
+      failed: failed,
+      processed_at: "2026-01-30T12:00:00Z"
+    )
+    assert_equal "msg-123", msg.uuid
+    assert_equal "session-abc", msg.session_id
+    assert_equal files, msg.files
+    assert_equal failed, msg.failed
+    assert_equal "2026-01-30T12:00:00Z", msg.processed_at
+    assert_equal :files_persisted, msg.type
+  end
+
+  test "files_persisted_event_defaults" do
+    msg = ClaudeAgent::FilesPersistedEvent.new(
+      uuid: "msg-123",
+      session_id: "session-abc"
+    )
+    assert_equal [], msg.files
+    assert_equal [], msg.failed
+    assert_nil msg.processed_at
+  end
+
+  test "files_persisted_event_in_types_constant" do
+    assert_includes ClaudeAgent::MESSAGE_TYPES, ClaudeAgent::FilesPersistedEvent
+  end
 end

--- a/test/integration/test_message_parser.rb
+++ b/test/integration/test_message_parser.rb
@@ -219,4 +219,22 @@ class TestIntegrationMessageParser < IntegrationTestCase
     assert auth.is_authenticating
     assert_equal [ "Waiting for browser..." ], auth.output
   end
+
+  test "message parser - files persisted event" do
+    raw = {
+      "type" => "system",
+      "subtype" => "files_persisted",
+      "uuid" => "msg-123",
+      "session_id" => "sess-abc",
+      "files" => [ { "filename" => "test.rb", "file_id" => "file-456" } ],
+      "failed" => [],
+      "processed_at" => "2026-01-30T12:00:00Z"
+    }
+    msg = @parser.parse(raw)
+    assert_kind_of ClaudeAgent::FilesPersistedEvent, msg
+    assert_equal :files_persisted, msg.type
+    assert_equal 1, msg.files.length
+    assert_equal "test.rb", msg.files.first["filename"]
+    assert_equal "2026-01-30T12:00:00Z", msg.processed_at
+  end
 end

--- a/test/integration/test_messages.rb
+++ b/test/integration/test_messages.rb
@@ -38,6 +38,7 @@ class TestIntegrationMessages < IntegrationTestCase
     assert ClaudeAgent::MESSAGE_TYPES.include?(ClaudeAgent::HookStartedMessage)
     assert ClaudeAgent::MESSAGE_TYPES.include?(ClaudeAgent::HookProgressMessage)
     assert ClaudeAgent::MESSAGE_TYPES.include?(ClaudeAgent::ToolUseSummaryMessage)
+    assert ClaudeAgent::MESSAGE_TYPES.include?(ClaudeAgent::FilesPersistedEvent)
   end
 
   test "TaskNotificationMessage type" do
@@ -193,5 +194,34 @@ class TestIntegrationMessages < IntegrationTestCase
     )
 
     assert_equal [], msg.preceding_tool_use_ids
+  end
+
+  test "FilesPersistedEvent type" do
+    msg = ClaudeAgent::FilesPersistedEvent.new(
+      uuid: "msg-123",
+      session_id: "sess-456",
+      files: [ { "filename" => "test.rb", "file_id" => "file-789" } ],
+      failed: [ { "filename" => "bad.rb", "error" => "Permission denied" } ],
+      processed_at: "2026-01-30T12:00:00Z"
+    )
+
+    assert_equal :files_persisted, msg.type
+    assert_equal "msg-123", msg.uuid
+    assert_equal "sess-456", msg.session_id
+    assert_equal 1, msg.files.length
+    assert_equal "test.rb", msg.files.first["filename"]
+    assert_equal 1, msg.failed.length
+    assert_equal "2026-01-30T12:00:00Z", msg.processed_at
+  end
+
+  test "FilesPersistedEvent defaults" do
+    msg = ClaudeAgent::FilesPersistedEvent.new(
+      uuid: "msg-123",
+      session_id: "sess-456"
+    )
+
+    assert_equal [], msg.files
+    assert_equal [], msg.failed
+    assert_nil msg.processed_at
   end
 end


### PR DESCRIPTION
## What
Adds `FilesPersistedEvent` message type and updates SPEC.md to reflect full TypeScript SDK v0.2.25 parity.

## Why
The TypeScript SDK v0.2.25 introduced `SDKFilesPersistedEvent` and `McpClaudeAIProxyServerConfig`. This brings the Ruby SDK to complete feature parity. SPEC.md also needed updating to reflect the latest Python SDK (v0.1.25) changes and correct stale "near-complete" wording.

## How
- Added `FilesPersistedEvent` Data.define type with `files`, `failed`, and `processed_at` fields
- Added message parser support for `files_persisted` subtype
- Updated RBS type signatures
- Updated SPEC.md reference versions (TS v0.2.25, Python v0.1.25) and Python SDK coverage notes
- Added `claudeai-proxy` MCP server type to SPEC.md
- Unit and integration tests for the new message type
- Updated CHANGELOG.md

## Test plan
- [x] Unit tests for `FilesPersistedEvent` construction and defaults
- [x] Unit tests for message parser with snake_case, camelCase, and missing fields
- [x] Integration tests for message type and parser
- [x] RBS type signatures updated