### PR TITLE
feat(mcp): add tool annotations and update docs for TS v0.2.27 parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- MCP tool annotations support (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`, `title`) on `MCP::Tool` and `MCP.tool` convenience method (TypeScript SDK v0.2.27 parity)
+- README documentation for `UserMessageReplay`, `HookStartedMessage`, `HookProgressMessage`, `ToolUseSummaryMessage`, `FilesPersistedEvent` message types
+- README documentation for `mcp_reconnect` and `mcp_toggle` client methods
+- README documentation for MCP tool annotations
+
+### Changed
+- Updated SPEC.md to reference TypeScript SDK v0.2.27 and Python SDK v0.1.26
+
 ## [0.6.0] - 2026-01-30
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # ClaudeAgent Ruby SDK
 
-Ruby SDK for building autonomous AI agents that interact with Claude Code CLI.
+Ruby SDK for building autonomous AI agents that interact with Claude Code CLI. See [README.md](README.md) for API usage, message types, configuration, and examples.
 
 ## Stack
 
@@ -32,16 +32,6 @@ bin/rbs-validate                   # Validate RBS signatures
 bin/release VERSION                # Release gem (e.g., bin/release 1.2.0)
 ```
 
-## Architecture
-
-| Component                   | Purpose                                            |
-|-----------------------------|----------------------------------------------------|
-| `Query`                     | One-shot stateless prompts                         |
-| `Client`                    | Multi-turn bidirectional conversations             |
-| `ControlProtocol`           | Handles handshake, hooks, permissions, MCP routing |
-| `Transport::Subprocess`     | Spawns CLI, manages stdin/stdout                   |
-| `MCP::Tool` / `MCP::Server` | Custom tool definitions                            |
-
 ## Conventions
 
 - **Immutable data types**: All messages and options use `Data.define`
@@ -49,25 +39,6 @@ bin/release VERSION                # Release gem (e.g., bin/release 1.2.0)
 - **Message polymorphism**: Use `case` statements or `is_a?()` for content block types
 - **Error hierarchy**: All errors inherit from `ClaudeAgent::Error` with context (exit code, stderr, etc.)
 - **Protocol flow**: Transport → ControlProtocol → MessageParser → typed message objects
-
-## Key Patterns
-
-```ruby
-# One-shot query
-result = ClaudeAgent.query("prompt", model: "sonnet")
-
-# Interactive client
-client = ClaudeAgent::Client.new(options)
-client.send_message("prompt") { |msg| handle(msg) }
-
-# Content blocks are polymorphic
-message.content.each do |block|
-  case block
-  when ClaudeAgent::TextBlock then ...
-  when ClaudeAgent::ToolUseBlock then ...
-  end
-end
-```
 
 ## Testing Notes
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Ruby gem for building AI-powered applications with the [Claude Agent SDK](https:
 ## Requirements
 
 - Ruby 3.2+ (uses `Data.define`)
-- [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code/getting-started) v2.0.0+
+- [Claude Code CLI](https://code.claude.com/docs/en/getting-started) v2.0.0+
 
 ## Installation
 
@@ -226,6 +226,19 @@ result.errors          # Array of error messages (if any)
 result.permission_denials  # Array of SDKPermissionDenial (if any)
 ```
 
+### UserMessageReplay
+
+Replayed user messages when resuming a session with existing history:
+
+```ruby
+replay.content             # Message content
+replay.uuid                # Message UUID
+replay.session_id          # Session identifier
+replay.parent_tool_use_id  # Parent tool use ID (if tool result)
+replay.replay?             # true if this is a replayed message
+replay.synthetic?          # true if this is a synthetic message
+```
+
 ### SystemMessage
 
 Internal system events:
@@ -287,6 +300,48 @@ hook_response.hook_event # Hook event type
 hook_response.stdout     # Hook stdout
 hook_response.stderr     # Hook stderr
 hook_response.exit_code  # Exit code
+```
+
+### HookStartedMessage
+
+Hook execution start notification:
+
+```ruby
+hook_started.hook_id    # Hook identifier
+hook_started.hook_name  # Hook name
+hook_started.hook_event # Hook event type
+```
+
+### HookProgressMessage
+
+Progress during hook execution:
+
+```ruby
+hook_progress.hook_id    # Hook identifier
+hook_progress.hook_name  # Hook name
+hook_progress.hook_event # Hook event type
+hook_progress.stdout     # Hook stdout so far
+hook_progress.stderr     # Hook stderr so far
+hook_progress.output     # Combined output
+```
+
+### ToolUseSummaryMessage
+
+Summary of tool use for collapsed display:
+
+```ruby
+summary.summary                  # Human-readable summary text
+summary.preceding_tool_use_ids   # Tool use IDs this summarizes
+```
+
+### FilesPersistedEvent
+
+Files persisted to storage during a session:
+
+```ruby
+persisted.files        # Array of successfully persisted file paths
+persisted.failed       # Array of files that failed to persist
+persisted.processed_at # Timestamp of persistence
 ```
 
 ### AuthStatusMessage
@@ -412,6 +467,33 @@ schema: {
   required: ["name"]
 }
 ```
+
+### Tool Annotations
+
+Annotate tools with hints about their behavior:
+
+```ruby
+tool = ClaudeAgent::MCP::Tool.new(
+  name: "search",
+  description: "Search the web",
+  schema: { query: String },
+  annotations: {
+    readOnlyHint: true,       # Tool only reads data, no side effects
+    destructiveHint: false,   # Tool does not destroy/delete data
+    idempotentHint: true,     # Repeated calls with same args have same effect
+    openWorldHint: true,      # Tool interacts with external systems
+    title: "Web Search"       # Human-readable display name
+  }
+) { |args| "Results for #{args['query']}" }
+
+# Or with the convenience method
+tool = ClaudeAgent::MCP.tool(
+  "search", "Search the web", { query: String },
+  annotations: { readOnlyHint: true, openWorldHint: true }
+) { |args| "Results" }
+```
+
+All annotation fields are optional hints — omit any that don't apply.
 
 ### Tool Return Values
 
@@ -621,6 +703,13 @@ result = client.set_mcp_servers({
   "my-server" => { type: "stdio", command: "node", args: ["server.js"] }
 })
 puts "Added: #{result.added}, Removed: #{result.removed}"
+
+# Reconnect a disconnected MCP server
+client.mcp_reconnect("my-server")
+
+# Enable or disable an MCP server
+client.mcp_toggle("my-server", enabled: false)  # Disable
+client.mcp_toggle("my-server", enabled: true)   # Re-enable
 
 # Query capabilities
 client.supported_commands.each { |cmd| puts "#{cmd.name}: #{cmd.description}" }

--- a/SPEC.md
+++ b/SPEC.md
@@ -3,11 +3,11 @@
 This document provides a comprehensive specification of the Claude Agent SDK, comparing feature parity across the official TypeScript and Python SDKs with this Ruby implementation.
 
 **Reference Versions:**
-- TypeScript SDK: v0.2.25 (npm package)
-- Python SDK: v0.1.25 from GitHub (commit 1bf665c)
+- TypeScript SDK: v0.2.27 (npm package)
+- Python SDK: v0.1.26 from GitHub (commit 438ddf7)
 - Ruby SDK: This repository
 
-**Last Updated:** 2026-01-30
+**Last Updated:** 2026-01-31
 
 ---
 
@@ -424,7 +424,7 @@ Permission handling and updates.
 |------------------|:----------:|:------:|:----:|---------------------------|
 | `signal`         |     ✅      |   ✅    |  ✅   | Abort signal              |
 | `suggestions`    |     ✅      |   ✅    |  ✅   | Permission suggestions    |
-| `blockedPath`    |     ✅      |   ✅    |  ✅   | Blocked file path         |
+| `blockedPath`    |     ✅      |   ❌    |  ✅   | Blocked file path         |
 | `decisionReason` |     ✅      |   ❌    |  ✅   | Why permission triggered  |
 | `toolUseID`      |     ✅      |   ❌    |  ✅   | Tool call ID              |
 | `agentID`        |     ✅      |   ❌    |  ✅   | Subagent ID if applicable |
@@ -474,11 +474,12 @@ Model Context Protocol server support.
 
 ### SDK MCP Server
 
-| Feature              | TypeScript | Python |         Ruby         | Notes                  |
-|----------------------|:----------:|:------:|:--------------------:|------------------------|
-| `createSdkMcpServer` |     ✅      |   ❌    |          ✅           | Create SDK server      |
-| `tool()` helper      |     ✅      |   ❌    |          ✅           | Create tool definition |
-| Tool input schema    |  ✅ (Zod)   |   ❌    | ✅ (Hash/JSON Schema) | Schema definition      |
+| Feature              | TypeScript | Python |         Ruby         | Notes                    |
+|----------------------|:----------:|:------:|:--------------------:|--------------------------|
+| `createSdkMcpServer` |     ✅      |   ❌    |          ✅           | Create SDK server        |
+| `tool()` helper      |     ✅      |   ❌    |          ✅           | Create tool definition   |
+| Tool input schema    |  ✅ (Zod)   |   ❌    | ✅ (Hash/JSON Schema) | Schema definition        |
+| Tool annotations     |     ✅      |   ❌    |          ✅           | MCP tool hints (v0.2.27) |
 
 ---
 
@@ -611,6 +612,8 @@ Public API surface for SDK clients.
 | `accountInfo()`          |     ✅      |   ❌    |  ✅   | Get account info       |
 | `rewindFiles()`          |     ✅      |   ✅    |  ✅   | Rewind file changes    |
 | `setMcpServers()`        |     ✅      |   ❌    |  ✅   | Dynamic MCP servers    |
+| `reconnectMcpServer()`   |     ✅      |   ❌    |  ✅   | Reconnect MCP server   |
+| `toggleMcpServer()`      |     ✅      |   ❌    |  ✅   | Enable/disable MCP     |
 | `streamInput()`          |     ✅      |   ✅    |  ✅   | Stream user input      |
 | `close()`                |     ✅      |   ✅    |  ✅   | Close query/session    |
 
@@ -663,9 +666,12 @@ Public API surface for SDK clients.
 - v0.2.19 adds `HookStartedMessage`, `HookProgressMessage`, and `ToolUseSummaryMessage`
 - v0.2.25 adds `SDKFilesPersistedEvent` message type for file persistence confirmation
 - v0.2.25 adds `McpClaudeAIProxyServerConfig` (`claudeai-proxy` type) for managed proxy servers
+- v0.2.21 adds `reconnectMcpServer()` and `toggleMcpServer()` query methods
+- v0.2.21 adds `config`, `scope`, `tools` fields and `disabled` status to `McpServerStatus`
+- v0.2.27 adds optional `annotations` support to `tool()` helper for MCP tool hints
 
 ### Python SDK
-- Full source available (v0.1.25)
+- Full source available (v0.1.26)
 - Now has `Transport` abstract class and several query control methods
 - Supports `interrupt()`, `set_permission_mode()`, `set_model()`, `rewind_files()`, `stream_input()`, `close()`, `get_mcp_status()` in query
 - Client also supports `interrupt()`, `set_permission_mode()`, `set_model()`, `rewind_files()`
@@ -676,6 +682,7 @@ Public API surface for SDK clients.
 - `excludedCommands` in sandbox now supported
 - v0.1.25 adds `PostToolUseFailure` hook event support
 - v0.1.25 adds `permissionDecisionReason` to `PreToolUseHookSpecificOutput`
+- v0.1.26 bumps bundled CLI to v2.1.27 (no new SDK features beyond PostToolUseFailure)
 - `additionalContext` supported in `UserPromptSubmitHookSpecificOutput`
 - `PreToolUseHookInput` does not include `tool_use_id` (unlike TypeScript)
 - `ToolPermissionContext` missing `blockedPath`, `decisionReason`, `toolUseID`, `agentID`
@@ -690,3 +697,4 @@ Public API surface for SDK clients.
 - `executable`/`executableArgs` marked N/A (JS runtime options not applicable to Ruby)
 - Added: `FilesPersistedEvent` message type (new in TS v0.2.25)
 - `claudeai-proxy` MCP server type handled transparently via Hash-based config passthrough (new in TS v0.2.25)
+- Added: MCP tool `annotations` support (new in TS v0.2.27)

--- a/lib/claude_agent/mcp/server.rb
+++ b/lib/claude_agent/mcp/server.rb
@@ -150,8 +150,8 @@ module ClaudeAgent
     #     "Hello, #{args['name']}!"
     #   end
     #
-    def self.tool(name, description, schema = {}, &handler)
-      Tool.new(name: name, description: description, schema: schema, &handler)
+    def self.tool(name, description, schema = {}, annotations: nil, &handler)
+      Tool.new(name: name, description: description, schema: schema, annotations: annotations, &handler)
     end
 
     # Convenience method to create a server

--- a/lib/claude_agent/mcp/tool.rb
+++ b/lib/claude_agent/mcp/tool.rb
@@ -34,16 +34,18 @@ module ClaudeAgent
     #   end
     #
     class Tool
-      attr_reader :name, :description, :schema, :handler
+      attr_reader :name, :description, :schema, :annotations, :handler
 
       # @param name [String] Tool name (must be unique within server)
       # @param description [String] Description of what the tool does
       # @param schema [Hash] Input schema (simple Ruby types or JSON Schema)
+      # @param annotations [Hash, nil] MCP tool annotations (readOnlyHint, destructiveHint, etc.)
       # @param handler [Proc] Block to execute when tool is called
-      def initialize(name:, description:, schema: {}, &handler)
+      def initialize(name:, description:, schema: {}, annotations: nil, &handler)
         @name = name.to_s
         @description = description.to_s
         @schema = normalize_schema(schema)
+        @annotations = annotations
         @handler = handler || ->(args) { raise "No handler defined for tool #{name}" }
       end
 
@@ -60,11 +62,13 @@ module ClaudeAgent
       # Convert to MCP tool definition format
       # @return [Hash]
       def to_mcp_definition
-        {
+        definition = {
           name: @name,
           description: @description,
           inputSchema: @schema
         }
+        definition[:annotations] = @annotations if @annotations.present?
+        definition
       end
 
       private

--- a/sig/claude_agent.rbs
+++ b/sig/claude_agent.rbs
@@ -967,15 +967,16 @@ module ClaudeAgent
 
   # MCP module
   module MCP
-    def self.tool: (String name, String description, ?Hash[Symbol, untyped] schema) { (Hash[String, untyped]) -> untyped } -> Tool
+    def self.tool: (String name, String description, ?Hash[Symbol, untyped] schema, ?annotations: Hash[Symbol, untyped]?) { (Hash[String, untyped]) -> untyped } -> Tool
     def self.create_server: (name: String, ?tools: Array[Tool]) -> Server
 
     class Tool
       attr_reader name: String
       attr_reader description: String
       attr_reader schema: Hash[Symbol, untyped]
+      attr_reader annotations: Hash[Symbol, untyped]?
 
-      def initialize: (name: String, description: String, ?schema: Hash[Symbol, untyped]) { (Hash[String, untyped]) -> untyped } -> void
+      def initialize: (name: String, description: String, ?schema: Hash[Symbol, untyped], ?annotations: Hash[Symbol, untyped]?) { (Hash[String, untyped]) -> untyped } -> void
       def call: (Hash[String, untyped] arguments) -> Hash[Symbol, untyped]
       def to_mcp_definition: () -> Hash[Symbol, untyped]
     end

--- a/test/claude_agent/mcp/test_server.rb
+++ b/test/claude_agent/mcp/test_server.rb
@@ -161,6 +161,14 @@ class TestClaudeAgentMCPServer < ActiveSupport::TestCase
     assert_equal 1, server.tools.length
   end
 
+  test "convenience_tool_with_annotations" do
+    annotations = { readOnlyHint: true, openWorldHint: true }
+    tool = ClaudeAgent::MCP.tool("search", "Search", { q: String }, annotations: annotations) { |args| "ok" }
+
+    assert_instance_of ClaudeAgent::MCP::Tool, tool
+    assert_equal annotations, tool.annotations
+  end
+
   test "add_tool_with_numeric_calculation" do
     message = {
       "jsonrpc" => "2.0",

--- a/test/claude_agent/mcp/test_tool.rb
+++ b/test/claude_agent/mcp/test_tool.rb
@@ -115,6 +115,49 @@ class TestClaudeAgentMCPTool < ActiveSupport::TestCase
     assert definition[:inputSchema]
   end
 
+  test "tool_with_annotations" do
+    annotations = {
+      readOnlyHint: true,
+      destructiveHint: false,
+      openWorldHint: true
+    }
+
+    tool = ClaudeAgent::MCP::Tool.new(
+      name: "search",
+      description: "Search the web",
+      schema: { query: String },
+      annotations: annotations
+    ) { |args| "Results for #{args['query']}" }
+
+    assert_equal annotations, tool.annotations
+
+    definition = tool.to_mcp_definition
+    assert_equal annotations, definition[:annotations]
+  end
+
+  test "tool_without_annotations_omits_key" do
+    tool = ClaudeAgent::MCP::Tool.new(
+      name: "test",
+      description: "Test"
+    ) { |_| "ok" }
+
+    assert_nil tool.annotations
+
+    definition = tool.to_mcp_definition
+    refute definition.key?(:annotations)
+  end
+
+  test "tool_with_empty_annotations_omits_key" do
+    tool = ClaudeAgent::MCP::Tool.new(
+      name: "test",
+      description: "Test",
+      annotations: {}
+    ) { |_| "ok" }
+
+    definition = tool.to_mcp_definition
+    refute definition.key?(:annotations)
+  end
+
   test "type_conversions" do
     # Test various Ruby type conversions
     tool = ClaudeAgent::MCP::Tool.new(

--- a/test/integration/test_mcp.rb
+++ b/test/integration/test_mcp.rb
@@ -54,6 +54,40 @@ class TestIntegrationMcp < IntegrationTestCase
     assert_equal 2, response[:result][:tools].length
   end
 
+  test "MCP tool annotations in tools/list" do
+    annotations = { readOnlyHint: true, destructiveHint: false, openWorldHint: true }
+
+    tool = ClaudeAgent::MCP::Tool.new(
+      name: "search",
+      description: "Search the web",
+      schema: { query: String },
+      annotations: annotations
+    ) { |args| "Results for #{args['query']}" }
+
+    server = ClaudeAgent::MCP::Server.new(name: "annotated", tools: [ tool ])
+
+    response = server.handle_message({ "method" => "tools/list", "id" => 1 })
+    listed_tool = response[:result][:tools].first
+
+    assert_equal "search", listed_tool[:name]
+    assert_equal annotations, listed_tool[:annotations]
+  end
+
+  test "MCP tool without annotations omits key in tools/list" do
+    tool = ClaudeAgent::MCP::Tool.new(
+      name: "plain",
+      description: "No annotations"
+    ) { "ok" }
+
+    server = ClaudeAgent::MCP::Server.new(name: "plain", tools: [ tool ])
+
+    response = server.handle_message({ "method" => "tools/list", "id" => 1 })
+    listed_tool = response[:result][:tools].first
+
+    assert_equal "plain", listed_tool[:name]
+    refute listed_tool.key?(:annotations)
+  end
+
   test "McpSetServersResult type" do
     result = ClaudeAgent::McpSetServersResult.new(
       added: [ "server1", "server2" ],


### PR DESCRIPTION
## What
Add MCP tool annotations support and update documentation to achieve full SDK parity with TypeScript v0.2.27 and Python v0.1.26.

## Why
The TypeScript SDK v0.2.27 added tool annotations, leaving the Ruby SDK one feature behind. The README was also missing documentation for several message types and client methods that were already implemented.

## How
- Added `annotations` parameter to `MCP::Tool` and `MCP.tool` convenience method
- Updated SPEC.md reference versions (TS v0.2.25→v0.2.27, Python v0.1.25→v0.1.26)
- Added README sections for: UserMessageReplay, HookStartedMessage, HookProgressMessage, ToolUseSummaryMessage, FilesPersistedEvent, tool annotations, `mcp_reconnect`/`mcp_toggle`
- Removed duplicated content from CLAUDE.md, linking to README instead
- Added unit, integration, and RBS type signature coverage