### PR TITLE
feat: complete SDK parity with TypeScript v0.2.31

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -80,8 +80,8 @@ Configuration options for SDK queries and clients.
 | `init`                            |     ✅      |   ❌    |  ✅   | Run Setup hooks (init trigger), then continue (hidden CLI)   |
 | `initOnly`                        |     ✅      |   ❌    |  ✅   | Run Setup hooks (init trigger), then exit (hidden CLI)       |
 | `maintenance`                     |     ✅      |   ❌    |  ✅   | Run Setup hooks (maintenance trigger), continue (hidden CLI) |
-| `debug`                           |     ✅      |   ❌    |  ❌   | Enable verbose debug logging                                 |
-| `debugFile`                       |     ✅      |   ❌    |  ❌   | Write debug logs to specific file path                       |
+| `debug`                           |     ✅      |   ❌    |  ✅   | Enable verbose debug logging                                 |
+| `debugFile`                       |     ✅      |   ❌    |  ✅   | Write debug logs to specific file path                       |
 
 ---
 
@@ -128,7 +128,7 @@ Messages exchanged between SDK and CLI.
 | `errors`             |     ✅      |   ❌    |  ✅   | Error messages           |
 | `uuid`               |     ✅      |   ❌    |  ✅   | Message UUID             |
 | `session_id`         |     ✅      |   ✅    |  ✅   | Session ID               |
-| `stop_reason`        |     ✅      |   ❌    |  ❌   | Why model stopped        |
+| `stop_reason`        |     ✅      |   ❌    |  ✅   | Why model stopped        |
 
 #### Result Subtypes
 
@@ -671,9 +671,8 @@ Public API surface for SDK clients.
 - `ToolPermissionContext` missing `blockedPath`, `decisionReason`, `toolUseID`, `agentID`
 
 ### Ruby SDK (This Repository)
-- Near-full TypeScript SDK feature parity
+- Full TypeScript SDK v0.2.31 feature parity
 - Ruby-idiomatic patterns (Data.define, snake_case)
 - Complete control protocol, hook, and V2 Session API support
 - Dedicated Client class for multi-turn conversations
 - `executable`/`executableArgs` marked N/A (JS runtime options)
-- Missing (v0.2.30+): `debug`/`debugFile` options, `stop_reason` in ResultMessage

--- a/lib/claude_agent/message_parser.rb
+++ b/lib/claude_agent/message_parser.rb
@@ -143,7 +143,8 @@ module ClaudeAgent
         structured_output: fetch_dual(raw, :structured_output),
         errors: raw["errors"],
         permission_denials: permission_denials,
-        model_usage: fetch_dual(raw, :model_usage)
+        model_usage: fetch_dual(raw, :model_usage),
+        stop_reason: fetch_dual(raw, :stop_reason)
       )
     end
 

--- a/lib/claude_agent/messages.rb
+++ b/lib/claude_agent/messages.rb
@@ -181,7 +181,8 @@ module ClaudeAgent
     :structured_output,
     :errors,             # Array<String> for error subtypes
     :permission_denials, # Array<SDKPermissionDenial>
-    :model_usage         # Hash with per-model usage breakdown
+    :model_usage,        # Hash with per-model usage breakdown
+    :stop_reason         # Why the model stopped generating (TypeScript SDK parity)
   ) do
     def initialize(
       subtype:,
@@ -196,7 +197,8 @@ module ClaudeAgent
       structured_output: nil,
       errors: nil,
       permission_denials: nil,
-      model_usage: nil
+      model_usage: nil,
+      stop_reason: nil
     )
       super
     end

--- a/lib/claude_agent/options.rb
+++ b/lib/claude_agent/options.rb
@@ -41,7 +41,9 @@ module ClaudeAgent
       betas: [],
       init: false,
       init_only: false,
-      maintenance: false
+      maintenance: false,
+      debug: false,
+      debug_file: nil
     }.freeze
 
     # All configurable attributes
@@ -59,6 +61,7 @@ module ClaudeAgent
       persist_session betas max_buffer_size stderr_callback
       abort_controller spawn_claude_code_process
       init init_only maintenance
+      debug debug_file
     ].freeze
 
     attr_accessor(*ATTRIBUTES)
@@ -88,6 +91,7 @@ module ClaudeAgent
         args.concat(environment_args)
         args.concat(output_args)
         args.concat(setup_hook_args)
+        args.concat(debug_args)
         args.concat(extra_cli_args)
       end
     end
@@ -240,6 +244,13 @@ module ClaudeAgent
         args.push("--init") if init
         args.push("--init-only") if init_only
         args.push("--maintenance") if maintenance
+      end
+    end
+
+    def debug_args
+      [].tap do |args|
+        args.push("--debug") if debug
+        args.push("--debug-file", debug_file) if debug_file
       end
     end
 

--- a/sig/claude_agent.rbs
+++ b/sig/claude_agent.rbs
@@ -301,6 +301,8 @@ module ClaudeAgent
     # Buffering & debugging
     attr_accessor max_buffer_size: Integer?
     attr_accessor stderr_callback: (^(String) -> void)?
+    attr_accessor debug: bool
+    attr_accessor debug_file: String?
 
     # Abort control (TypeScript SDK parity)
     attr_accessor abort_controller: AbortController?
@@ -463,6 +465,7 @@ module ClaudeAgent
     attr_reader errors: Array[String]?
     attr_reader permission_denials: Array[SDKPermissionDenial]?
     attr_reader model_usage: Hash[String, untyped]?
+    attr_reader stop_reason: String?
 
     def initialize: (
       subtype: String,
@@ -477,7 +480,8 @@ module ClaudeAgent
       ?structured_output: untyped,
       ?errors: Array[String]?,
       ?permission_denials: Array[SDKPermissionDenial]?,
-      ?model_usage: Hash[String, untyped]?
+      ?model_usage: Hash[String, untyped]?,
+      ?stop_reason: String?
     ) -> void
 
     def type: () -> :result

--- a/test/claude_agent/test_message_parser.rb
+++ b/test/claude_agent/test_message_parser.rb
@@ -175,6 +175,53 @@ class TestClaudeAgentMessageParser < ActiveSupport::TestCase
     assert_equal 0.05, msg.total_cost_usd
   end
 
+  test "parse_result_message_with_stop_reason" do
+    raw = {
+      "type" => "result",
+      "subtype" => "success",
+      "duration_ms" => 1500,
+      "duration_api_ms" => 1200,
+      "is_error" => false,
+      "num_turns" => 3,
+      "session_id" => "sess-123",
+      "stop_reason" => "end_turn"
+    }
+    msg = @parser.parse(raw)
+
+    assert_equal "end_turn", msg.stop_reason
+  end
+
+  test "parse_result_message_with_stop_reason_camel_case" do
+    raw = {
+      "type" => "result",
+      "subtype" => "success",
+      "durationMs" => 1500,
+      "durationApiMs" => 1200,
+      "isError" => false,
+      "numTurns" => 3,
+      "sessionId" => "sess-123",
+      "stopReason" => "max_tokens"
+    }
+    msg = @parser.parse(raw)
+
+    assert_equal "max_tokens", msg.stop_reason
+  end
+
+  test "parse_result_message_stop_reason_default_nil" do
+    raw = {
+      "type" => "result",
+      "subtype" => "success",
+      "duration_ms" => 1500,
+      "duration_api_ms" => 1200,
+      "is_error" => false,
+      "num_turns" => 3,
+      "session_id" => "sess-123"
+    }
+    msg = @parser.parse(raw)
+
+    assert_nil msg.stop_reason
+  end
+
   test "parse_stream_event" do
     raw = {
       "type" => "stream_event",

--- a/test/claude_agent/test_messages.rb
+++ b/test/claude_agent/test_messages.rb
@@ -129,6 +129,31 @@ class TestClaudeAgentMessages < ActiveSupport::TestCase
     refute msg.success?
   end
 
+  test "result_message_with_stop_reason" do
+    msg = ClaudeAgent::ResultMessage.new(
+      subtype: "success",
+      duration_ms: 1500,
+      duration_api_ms: 1200,
+      is_error: false,
+      num_turns: 3,
+      session_id: "session-abc",
+      stop_reason: "end_turn"
+    )
+    assert_equal "end_turn", msg.stop_reason
+  end
+
+  test "result_message_stop_reason_default_nil" do
+    msg = ClaudeAgent::ResultMessage.new(
+      subtype: "success",
+      duration_ms: 1500,
+      duration_api_ms: 1200,
+      is_error: false,
+      num_turns: 3,
+      session_id: "session-abc"
+    )
+    assert_nil msg.stop_reason
+  end
+
   test "stream_event" do
     event = ClaudeAgent::StreamEvent.new(
       uuid: "evt-123",

--- a/test/claude_agent/test_options.rb
+++ b/test/claude_agent/test_options.rb
@@ -417,4 +417,55 @@ class TestClaudeAgentOptions < ActiveSupport::TestCase
     end
     assert_match(/Only one of init, init_only, or maintenance/, error.message)
   end
+
+  # --- Debug Options ---
+
+  test "debug_option_default_false" do
+    options = ClaudeAgent::Options.new
+    assert_equal false, options.debug
+  end
+
+  test "debug_file_option_default_nil" do
+    options = ClaudeAgent::Options.new
+    assert_nil options.debug_file
+  end
+
+  test "debug_option_explicit_true" do
+    options = ClaudeAgent::Options.new(debug: true)
+    assert_equal true, options.debug
+  end
+
+  test "debug_file_option_with_path" do
+    options = ClaudeAgent::Options.new(debug_file: "/tmp/claude-debug.log")
+    assert_equal "/tmp/claude-debug.log", options.debug_file
+  end
+
+  test "to_cli_args_with_debug" do
+    options = ClaudeAgent::Options.new(debug: true)
+    args = options.to_cli_args
+    assert_includes args, "--debug"
+    refute_includes args, "--debug-file"
+  end
+
+  test "to_cli_args_with_debug_file" do
+    options = ClaudeAgent::Options.new(debug_file: "/tmp/debug.log")
+    args = options.to_cli_args
+    assert_includes args, "--debug-file"
+    assert_includes args, "/tmp/debug.log"
+  end
+
+  test "to_cli_args_with_debug_and_debug_file" do
+    options = ClaudeAgent::Options.new(debug: true, debug_file: "/tmp/debug.log")
+    args = options.to_cli_args
+    assert_includes args, "--debug"
+    assert_includes args, "--debug-file"
+    assert_includes args, "/tmp/debug.log"
+  end
+
+  test "to_cli_args_without_debug_options" do
+    options = ClaudeAgent::Options.new
+    args = options.to_cli_args
+    refute_includes args, "--debug"
+    refute_includes args, "--debug-file"
+  end
 end

--- a/test/integration/test_messages.rb
+++ b/test/integration/test_messages.rb
@@ -123,6 +123,29 @@ class TestIntegrationMessages < IntegrationTestCase
     assert result.model_usage.key?("claude-sonnet-4-5-20250514")
   end
 
+  test "ResultMessage stop_reason field" do
+    result_with_stop_reason = ClaudeAgent::ResultMessage.new(
+      subtype: "success",
+      duration_ms: 1000,
+      duration_api_ms: 800,
+      is_error: false,
+      num_turns: 1,
+      session_id: "session_123",
+      stop_reason: "end_turn"
+    )
+    assert_equal "end_turn", result_with_stop_reason.stop_reason
+
+    result_without_stop_reason = ClaudeAgent::ResultMessage.new(
+      subtype: "success",
+      duration_ms: 1000,
+      duration_api_ms: 800,
+      is_error: false,
+      num_turns: 1,
+      session_id: "session_123"
+    )
+    assert_nil result_without_stop_reason.stop_reason
+  end
+
   test "HookStartedMessage type" do
     msg = ClaudeAgent::HookStartedMessage.new(
       uuid: "msg-123",

--- a/test/integration/test_options.rb
+++ b/test/integration/test_options.rb
@@ -131,4 +131,42 @@ class TestIntegrationOptions < IntegrationTestCase
     args = bypass_options.to_cli_args
     assert args.include?("--dangerously-skip-permissions")
   end
+
+  test "options debug field" do
+    default_options = ClaudeAgent::Options.new
+    assert_equal false, default_options.debug
+
+    debug_options = ClaudeAgent::Options.new(debug: true)
+    assert_equal true, debug_options.debug
+
+    args = debug_options.to_cli_args
+    assert args.include?("--debug")
+
+    no_debug_args = default_options.to_cli_args
+    refute no_debug_args.include?("--debug")
+  end
+
+  test "options debug_file field" do
+    default_options = ClaudeAgent::Options.new
+    assert_nil default_options.debug_file
+
+    debug_file_options = ClaudeAgent::Options.new(debug_file: "/tmp/claude-debug.log")
+    assert_equal "/tmp/claude-debug.log", debug_file_options.debug_file
+
+    args = debug_file_options.to_cli_args
+    assert args.include?("--debug-file")
+    assert args.include?("/tmp/claude-debug.log")
+
+    no_debug_file_args = default_options.to_cli_args
+    refute no_debug_file_args.include?("--debug-file")
+  end
+
+  test "options debug and debug_file together" do
+    options = ClaudeAgent::Options.new(debug: true, debug_file: "/tmp/debug.log")
+
+    args = options.to_cli_args
+    assert args.include?("--debug")
+    assert args.include?("--debug-file")
+    assert args.include?("/tmp/debug.log")
+  end
 end

--- a/test/integration/test_query.rb
+++ b/test/integration/test_query.rb
@@ -49,6 +49,11 @@ class TestIntegrationQuery < IntegrationTestCase
     if result.total_cost_usd
       assert result.total_cost_usd >= 0, "Cost should be non-negative"
     end
+
+    # stop_reason is optional but should be a string if present
+    if result.stop_reason
+      assert result.stop_reason.is_a?(String), "stop_reason should be a String"
+    end
   end
 
   test "system message parsing" do


### PR DESCRIPTION
## What
Achieves full feature parity with TypeScript SDK v0.2.31 by adding debug options and stop_reason field.

## Why
The Ruby SDK was missing 3 features from the latest TypeScript SDK release. This brings the SDK to complete parity.

## Changes

### New Options
- `debug` - Enable verbose debug logging (`--debug` CLI flag)
- `debug_file` - Write debug logs to specific file path (`--debug-file`)

### New ResultMessage Field
- `stop_reason` - Indicates why the model stopped generating (e.g., "end_turn", "max_tokens")

### Updated
- SPEC.md updated to reflect full v0.2.31 parity
- RBS type signatures for new fields
- Unit and integration tests for all new features