### PR TITLE
feat: complete SDK parity with TypeScript v0.2.32

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -3,11 +3,11 @@
 This document provides a comprehensive specification of the Claude Agent SDK, comparing feature parity across the official TypeScript and Python SDKs with this Ruby implementation.
 
 **Reference Versions:**
-- TypeScript SDK: v0.2.31 (npm package)
-- Python SDK: v0.1.29 from GitHub (commit 7519c96)
+- TypeScript SDK: v0.2.32 (npm package)
+- Python SDK: v0.1.30 from GitHub (commit 451f2f4)
 - Ruby SDK: This repository
 
-**Last Updated:** 2026-02-03
+**Last Updated:** 2026-02-05
 
 ---
 
@@ -236,6 +236,7 @@ Bidirectional control protocol for SDK-CLI communication.
 | `ModelInfo`           |     ✅      |   ❌    |  ✅   | Model information      |
 | `McpServerStatus`     |     ✅      |   ❌    |  ✅   | MCP server status      |
 | `AccountInfo`         |     ✅      |   ❌    |  ✅   | Account information    |
+| `InitializationResult`|     ✅      |   ❌    |  ✅   | Full init response     |
 | `McpSetServersResult` |     ✅      |   ❌    |  ✅   | Set servers result     |
 | `RewindFilesResult`   |     ✅      |   ✅    |  ✅   | Rewind result          |
 
@@ -306,14 +307,14 @@ Event-specific fields returned via `hookSpecificOutput`:
 | `permissionDecision`       |     ✅      |   ✅    |  ✅   | `allow`, `deny`, or `ask`          |
 | `permissionDecisionReason` |     ✅      |   ✅    |  ✅   | Reason for permission decision     |
 | `updatedInput`             |     ✅      |   ✅    |  ✅   | Modified tool input                |
-| `additionalContext`        |     ✅      |   ❌    |  ✅   | Context string returned to model   |
+| `additionalContext`        |     ✅      |   ✅    |  ✅   | Context string returned to model   |
 
 #### PostToolUseHookSpecificOutput
 
 | Field                  | TypeScript | Python | Ruby | Notes                            |
 |------------------------|:----------:|:------:|:----:|----------------------------------|
 | `additionalContext`    |     ✅      |   ✅    |  ✅   | Context string returned to model |
-| `updatedMCPToolOutput` |     ✅      |   ❌    |  ✅   | Modified MCP tool output         |
+| `updatedMCPToolOutput` |     ✅      |   ✅    |  ✅   | Modified MCP tool output         |
 
 #### PostToolUseFailureHookSpecificOutput
 
@@ -325,7 +326,7 @@ Event-specific fields returned via `hookSpecificOutput`:
 
 | Field               | TypeScript | Python | Ruby | Notes                            |
 |---------------------|:----------:|:------:|:----:|----------------------------------|
-| `additionalContext` |     ✅      |   ❌    |  ✅   | Context string returned to model |
+| `additionalContext` |     ✅      |   ✅    |  ✅   | Context string returned to model |
 
 #### SetupHookSpecificOutput
 
@@ -337,7 +338,7 @@ Event-specific fields returned via `hookSpecificOutput`:
 
 | Field               | TypeScript | Python | Ruby | Notes                            |
 |---------------------|:----------:|:------:|:----:|----------------------------------|
-| `additionalContext` |     ✅      |   ❌    |  ✅   | Context string returned to model |
+| `additionalContext` |     ✅      |   ✅    |  ✅   | Context string returned to model |
 
 #### UserPromptSubmitHookSpecificOutput
 
@@ -349,13 +350,13 @@ Event-specific fields returned via `hookSpecificOutput`:
 
 | Field      | TypeScript | Python | Ruby | Notes                                    |
 |------------|:----------:|:------:|:----:|------------------------------------------|
-| `decision` |     ✅      |   ❌    |  ✅   | `{ behavior: 'allow'/'deny', ... }` obj  |
+| `decision` |     ✅      |   ✅    |  ✅   | `{ behavior: 'allow'/'deny', ... }` obj  |
 
 #### NotificationHookSpecificOutput
 
 | Field               | TypeScript | Python | Ruby | Notes                            |
 |---------------------|:----------:|:------:|:----:|----------------------------------|
-| `additionalContext` |     ✅      |   ❌    |  ✅   | Context string returned to model |
+| `additionalContext` |     ✅      |   ✅    |  ✅   | Context string returned to model |
 
 ### Hook Matcher
 
@@ -423,14 +424,15 @@ Permission handling and updates.
 
 ### ToolPermissionContext
 
-| Field            | TypeScript | Python | Ruby | Notes                     |
-|------------------|:----------:|:------:|:----:|---------------------------|
-| `signal`         |     ✅      |   ✅    |  ✅   | Abort signal              |
-| `suggestions`    |     ✅      |   ✅    |  ✅   | Permission suggestions    |
-| `blockedPath`    |     ✅      |   ❌    |  ✅   | Blocked file path         |
-| `decisionReason` |     ✅      |   ❌    |  ✅   | Why permission triggered  |
-| `toolUseID`      |     ✅      |   ❌    |  ✅   | Tool call ID              |
-| `agentID`        |     ✅      |   ❌    |  ✅   | Subagent ID if applicable |
+| Field            | TypeScript | Python | Ruby | Notes                           |
+|------------------|:----------:|:------:|:----:|---------------------------------|
+| `signal`         |     ✅      |   ✅    |  ✅   | Abort signal                    |
+| `suggestions`    |     ✅      |   ✅    |  ✅   | Permission suggestions          |
+| `blockedPath`    |     ✅      |   ❌    |  ✅   | Blocked file path               |
+| `decisionReason` |     ✅      |   ❌    |  ✅   | Why permission triggered        |
+| `toolUseID`      |     ✅      |   ❌    |  ✅   | Tool call ID                    |
+| `agentID`        |     ✅      |   ❌    |  ✅   | Subagent ID if applicable       |
+| `description`    |     ✅      |   ❌    |  ✅   | Human-readable tool description |
 
 ---
 
@@ -479,10 +481,10 @@ Model Context Protocol server support.
 
 | Feature              | TypeScript | Python |         Ruby         | Notes                    |
 |----------------------|:----------:|:------:|:--------------------:|--------------------------|
-| `createSdkMcpServer` |     ✅      |   ❌    |          ✅           | Create SDK server        |
-| `tool()` helper      |     ✅      |   ❌    |          ✅           | Create tool definition   |
-| Tool input schema    |  ✅ (Zod)   |   ❌    | ✅ (Hash/JSON Schema) | Schema definition        |
-| Tool annotations     |     ✅      |   ❌    |          ✅           | MCP tool hints (v0.2.27) |
+| `createSdkMcpServer` |     ✅      |   ✅    |          ✅           | Create SDK server        |
+| `tool()` helper      |     ✅      |   ✅    |          ✅           | Create tool definition   |
+| Tool input schema    |  ✅ (Zod)   |   ✅    | ✅ (Hash/JSON Schema) | Schema definition        |
+| Tool annotations     |     ✅      |   ✅    |          ✅           | MCP tool hints (v0.2.27) |
 
 ---
 
@@ -549,14 +551,15 @@ Sandbox configuration for command execution isolation.
 
 ### SandboxNetworkConfig
 
-| Field                 | TypeScript | Python | Ruby |
-|-----------------------|:----------:|:------:|:----:|
-| `allowedDomains`      |     ✅      |   ❌    |  ✅   |
-| `allowUnixSockets`    |     ✅      |   ✅    |  ✅   |
-| `allowAllUnixSockets` |     ✅      |   ✅    |  ✅   |
-| `allowLocalBinding`   |     ✅      |   ✅    |  ✅   |
-| `httpProxyPort`       |     ✅      |   ✅    |  ✅   |
-| `socksProxyPort`      |     ✅      |   ✅    |  ✅   |
+| Field                     | TypeScript | Python | Ruby |
+|---------------------------|:----------:|:------:|:----:|
+| `allowedDomains`          |     ✅      |   ❌    |  ✅   |
+| `allowManagedDomainsOnly` |     ✅      |   ❌    |  ✅   |
+| `allowUnixSockets`        |     ✅      |   ✅    |  ✅   |
+| `allowAllUnixSockets`     |     ✅      |   ✅    |  ✅   |
+| `allowLocalBinding`       |     ✅      |   ✅    |  ✅   |
+| `httpProxyPort`           |     ✅      |   ✅    |  ✅   |
+| `socksProxyPort`          |     ✅      |   ✅    |  ✅   |
 
 ---
 
@@ -618,6 +621,7 @@ Public API surface for SDK clients.
 | `reconnectMcpServer()`   |     ✅      |   ❌    |  ✅   | Reconnect MCP server   |
 | `toggleMcpServer()`      |     ✅      |   ❌    |  ✅   | Enable/disable MCP     |
 | `streamInput()`          |     ✅      |   ✅    |  ✅   | Stream user input      |
+| `initializationResult()` |     ✅      |   ❌    |  ✅   | Full init response     |
 | `close()`                |     ✅      |   ✅    |  ✅   | Close query/session    |
 
 ### Client Class
@@ -669,9 +673,11 @@ Public API surface for SDK clients.
 - Missing permission modes: `delegate`, `dontAsk`
 - Missing options: `allowDangerouslySkipPermissions`, `persistSession`, `resumeSessionAt`, `strictMcpConfig`, `init`/`initOnly`/`maintenance`, `debug`/`debugFile`
 - `ToolPermissionContext` missing `blockedPath`, `decisionReason`, `toolUseID`, `agentID`
+- Now has `additionalContext` in `PreToolUseHookSpecificOutput` (added in v0.1.30)
+- Now has `create_sdk_mcp_server`, `tool()` helper, and MCP tool annotations (added in v0.1.30)
 
 ### Ruby SDK (This Repository)
-- Full TypeScript SDK v0.2.31 feature parity
+- Full TypeScript SDK v0.2.32 feature parity
 - Ruby-idiomatic patterns (Data.define, snake_case)
 - Complete control protocol, hook, and V2 Session API support
 - Dedicated Client class for multi-turn conversations

--- a/lib/claude_agent/client.rb
+++ b/lib/claude_agent/client.rb
@@ -268,6 +268,15 @@ module ClaudeAgent
       @protocol.account_info
     end
 
+    # Get full initialization result (TypeScript SDK parity)
+    #
+    # @return [InitializationResult]
+    def initialization_result
+      require_connection!
+
+      @protocol.initialization_result
+    end
+
     # Dynamically set MCP servers for this session (TypeScript SDK parity)
     #
     # This replaces the current set of dynamically-added MCP servers.

--- a/lib/claude_agent/control_protocol.rb
+++ b/lib/claude_agent/control_protocol.rb
@@ -324,6 +324,51 @@ module ClaudeAgent
       end
     end
 
+    # Get full initialization result (TypeScript SDK parity)
+    #
+    # Sends the supported_commands request and maps the full response including
+    # commands, output style, available output styles, models, and account info.
+    #
+    # @return [InitializationResult]
+    def initialization_result
+      response = send_control_request(subtype: "supported_commands")
+
+      commands = (response["commands"] || []).map do |cmd|
+        SlashCommand.new(
+          name: cmd["name"],
+          description: cmd["description"],
+          argument_hint: cmd["argumentHint"]
+        )
+      end
+
+      models = (response["models"] || []).map do |model|
+        ModelInfo.new(
+          value: model["value"],
+          display_name: model["displayName"],
+          description: model["description"]
+        )
+      end
+
+      account_data = response["account"]
+      account = if account_data
+        AccountInfo.new(
+          email: account_data["email"],
+          organization: account_data["organization"],
+          subscription_type: account_data["subscriptionType"],
+          token_source: account_data["tokenSource"],
+          api_key_source: account_data["apiKeySource"]
+        )
+      end
+
+      InitializationResult.new(
+        commands: commands,
+        output_style: response["output_style"],
+        available_output_styles: response["available_output_styles"] || [],
+        models: models,
+        account: account
+      )
+    end
+
     # Get available models (TypeScript SDK parity)
     # @return [Array<ModelInfo>]
     def supported_models
@@ -536,7 +581,8 @@ module ClaudeAgent
         blocked_path: request["blocked_path"],
         decision_reason: request["decision_reason"],
         tool_use_id: request["tool_use_id"],
-        agent_id: request["agent_id"]
+        agent_id: request["agent_id"],
+        description: request["description"]
       }
 
       result = options.can_use_tool.call(tool_name, input, context)

--- a/lib/claude_agent/permissions.rb
+++ b/lib/claude_agent/permissions.rb
@@ -156,7 +156,8 @@ module ClaudeAgent
     :decision_reason,
     :tool_use_id,
     :agent_id,
-    :signal
+    :signal,
+    :description
   ) do
     def initialize(
       permission_suggestions: nil,
@@ -164,7 +165,8 @@ module ClaudeAgent
       decision_reason: nil,
       tool_use_id: nil,
       agent_id: nil,
-      signal: nil
+      signal: nil,
+      description: nil
     )
       super
     end

--- a/lib/claude_agent/sandbox_settings.rb
+++ b/lib/claude_agent/sandbox_settings.rb
@@ -15,6 +15,7 @@ module ClaudeAgent
     :allow_local_binding,
     :allow_unix_sockets,
     :allow_all_unix_sockets,
+    :allow_managed_domains_only,
     :http_proxy_port,
     :socks_proxy_port
   ) do
@@ -23,6 +24,7 @@ module ClaudeAgent
       allow_local_binding: false,
       allow_unix_sockets: [],
       allow_all_unix_sockets: false,
+      allow_managed_domains_only: false,
       http_proxy_port: nil,
       socks_proxy_port: nil
     )
@@ -35,6 +37,7 @@ module ClaudeAgent
       result[:allowLocalBinding] = allow_local_binding if allow_local_binding
       result[:allowUnixSockets] = allow_unix_sockets unless allow_unix_sockets.empty?
       result[:allowAllUnixSockets] = allow_all_unix_sockets if allow_all_unix_sockets
+      result[:allowManagedDomainsOnly] = allow_managed_domains_only if allow_managed_domains_only
       result[:httpProxyPort] = http_proxy_port if http_proxy_port
       result[:socksProxyPort] = socks_proxy_port if socks_proxy_port
       result

--- a/lib/claude_agent/types.rb
+++ b/lib/claude_agent/types.rb
@@ -80,6 +80,23 @@ module ClaudeAgent
     end
   end
 
+  # Composite initialization result from supported_commands request (TypeScript SDK parity)
+  #
+  # @example
+  #   result = InitializationResult.new(
+  #     commands: [SlashCommand.new(name: "commit")],
+  #     output_style: "default",
+  #     available_output_styles: ["default", "concise"],
+  #     models: [ModelInfo.new(value: "claude-sonnet")],
+  #     account: AccountInfo.new(email: "user@example.com")
+  #   )
+  #
+  InitializationResult = Data.define(:commands, :output_style, :available_output_styles, :models, :account) do
+    def initialize(commands: [], output_style: nil, available_output_styles: [], models: [], account: nil)
+      super
+    end
+  end
+
   # Per-model usage statistics returned in result messages (TypeScript SDK parity)
   #
   # @example

--- a/sig/claude_agent.rbs
+++ b/sig/claude_agent.rbs
@@ -114,6 +114,16 @@ module ClaudeAgent
     def initialize: (?email: String?, ?organization: String?, ?subscription_type: String?, ?token_source: String?, ?api_key_source: String?) -> void
   end
 
+  class InitializationResult
+    attr_reader commands: Array[SlashCommand]
+    attr_reader output_style: String?
+    attr_reader available_output_styles: Array[String]
+    attr_reader models: Array[ModelInfo]
+    attr_reader account: AccountInfo?
+
+    def initialize: (?commands: Array[SlashCommand], ?output_style: String?, ?available_output_styles: Array[String], ?models: Array[ModelInfo], ?account: AccountInfo?) -> void
+  end
+
   class ModelUsage
     attr_reader input_tokens: Integer
     attr_reader output_tokens: Integer
@@ -175,10 +185,11 @@ module ClaudeAgent
     attr_reader allow_local_binding: bool
     attr_reader allow_unix_sockets: Array[String]
     attr_reader allow_all_unix_sockets: bool
+    attr_reader allow_managed_domains_only: bool
     attr_reader http_proxy_port: Integer?
     attr_reader socks_proxy_port: Integer?
 
-    def initialize: (?allowed_domains: Array[String], ?allow_local_binding: bool, ?allow_unix_sockets: Array[String], ?allow_all_unix_sockets: bool, ?http_proxy_port: Integer?, ?socks_proxy_port: Integer?) -> void
+    def initialize: (?allowed_domains: Array[String], ?allow_local_binding: bool, ?allow_unix_sockets: Array[String], ?allow_all_unix_sockets: bool, ?allow_managed_domains_only: bool, ?http_proxy_port: Integer?, ?socks_proxy_port: Integer?) -> void
     def to_h: () -> Hash[Symbol, untyped]
   end
 
@@ -810,8 +821,9 @@ module ClaudeAgent
     attr_reader tool_use_id: String?
     attr_reader agent_id: String?
     attr_reader signal: AbortSignal?
+    attr_reader description: String?
 
-    def initialize: (?permission_suggestions: untyped, ?blocked_path: String?, ?decision_reason: String?, ?tool_use_id: String?, ?agent_id: String?, ?signal: AbortSignal?) -> void
+    def initialize: (?permission_suggestions: untyped, ?blocked_path: String?, ?decision_reason: String?, ?tool_use_id: String?, ?agent_id: String?, ?signal: AbortSignal?, ?description: String?) -> void
   end
 
   # Client
@@ -847,6 +859,7 @@ module ClaudeAgent
     def supported_models: () -> Array[ModelInfo]
     def mcp_server_status: () -> Array[McpServerStatus]
     def account_info: () -> AccountInfo
+    def initialization_result: () -> InitializationResult
   end
 
   # Control protocol
@@ -882,6 +895,7 @@ module ClaudeAgent
     def supported_models: () -> Array[ModelInfo]
     def mcp_server_status: () -> Array[McpServerStatus]
     def account_info: () -> AccountInfo
+    def initialization_result: () -> InitializationResult
   end
 
   # Transport layer

--- a/test/claude_agent/test_control_protocol.rb
+++ b/test/claude_agent/test_control_protocol.rb
@@ -194,6 +194,20 @@ class TestClaudeAgentControlProtocol < ActiveSupport::TestCase
     assert_equal "my-server", msg["request"]["serverName"]
   end
 
+  test "initialization_result sends supported_commands request format" do
+    @transport.connect
+
+    @protocol.send(:write_message, {
+      type: "control_request",
+      request_id: "test-req",
+      request: { subtype: "supported_commands" }
+    })
+
+    msg = @transport.written_messages.find { |m| m["type"] == "control_request" }
+    assert_not_nil msg
+    assert_equal "supported_commands", msg["request"]["subtype"]
+  end
+
   test "mcp_toggle sends correct request format" do
     @transport.connect
 

--- a/test/claude_agent/test_permissions.rb
+++ b/test/claude_agent/test_permissions.rb
@@ -270,4 +270,18 @@ class TestClaudeAgentPermissions < ActiveSupport::TestCase
     context = ClaudeAgent::ToolPermissionContext.new
     assert_nil context.signal
   end
+
+  test "tool_permission_context_with_description" do
+    context = ClaudeAgent::ToolPermissionContext.new(
+      description: "Read a file from the filesystem",
+      tool_use_id: "tool-123"
+    )
+    assert_equal "Read a file from the filesystem", context.description
+    assert_equal "tool-123", context.tool_use_id
+  end
+
+  test "tool_permission_context_description_default" do
+    context = ClaudeAgent::ToolPermissionContext.new
+    assert_nil context.description
+  end
 end

--- a/test/claude_agent/test_sandbox_settings.rb
+++ b/test/claude_agent/test_sandbox_settings.rb
@@ -28,6 +28,7 @@ class TestClaudeAgentSandboxSettings < ActiveSupport::TestCase
     refute config.allow_local_binding
     assert_equal [], config.allow_unix_sockets
     refute config.allow_all_unix_sockets
+    refute config.allow_managed_domains_only
     assert_nil config.http_proxy_port
     assert_nil config.socks_proxy_port
   end
@@ -52,6 +53,23 @@ class TestClaudeAgentSandboxSettings < ActiveSupport::TestCase
     config = ClaudeAgent::SandboxNetworkConfig.new
     h = config.to_h
     assert_equal({}, h)
+  end
+
+  test "sandbox_network_config_allow_managed_domains_only" do
+    config = ClaudeAgent::SandboxNetworkConfig.new(
+      allow_managed_domains_only: true,
+      allowed_domains: [ "api.example.com" ]
+    )
+    assert config.allow_managed_domains_only
+    h = config.to_h
+    assert h[:allowManagedDomainsOnly]
+    assert_equal [ "api.example.com" ], h[:allowedDomains]
+  end
+
+  test "sandbox_network_config_to_h_omits_false_allow_managed_domains_only" do
+    config = ClaudeAgent::SandboxNetworkConfig.new(allow_managed_domains_only: false)
+    h = config.to_h
+    refute h.key?(:allowManagedDomainsOnly)
   end
 
   # --- SandboxIgnoreViolations ---

--- a/test/claude_agent/test_types.rb
+++ b/test/claude_agent/test_types.rb
@@ -307,6 +307,36 @@ class TestClaudeAgentTypes < ActiveSupport::TestCase
     refute h.key?(:maxTurns)
   end
 
+  # --- InitializationResult ---
+
+  test "initialization_result" do
+    commands = [ ClaudeAgent::SlashCommand.new(name: "commit", description: "Create a commit") ]
+    models = [ ClaudeAgent::ModelInfo.new(value: "claude-sonnet", display_name: "Claude Sonnet") ]
+    account = ClaudeAgent::AccountInfo.new(email: "user@example.com")
+
+    result = ClaudeAgent::InitializationResult.new(
+      commands: commands,
+      output_style: "default",
+      available_output_styles: [ "default", "concise" ],
+      models: models,
+      account: account
+    )
+    assert_equal commands, result.commands
+    assert_equal "default", result.output_style
+    assert_equal [ "default", "concise" ], result.available_output_styles
+    assert_equal models, result.models
+    assert_equal account, result.account
+  end
+
+  test "initialization_result_defaults" do
+    result = ClaudeAgent::InitializationResult.new
+    assert_equal [], result.commands
+    assert_nil result.output_style
+    assert_equal [], result.available_output_styles
+    assert_equal [], result.models
+    assert_nil result.account
+  end
+
   # --- API Key Sources ---
 
   test "api_key_sources_constant" do


### PR DESCRIPTION
## What
Implements 3 missing features to bring the Ruby SDK to full parity with TypeScript SDK v0.2.32.

## Why
The Ruby SDK was at v0.2.31 parity with 3 small gaps remaining. This closes the gap entirely.

## How
- **`description` on ToolPermissionContext**: Added optional field to `Data.define`, extracted from control request hash, with RBS signature and tests.
- **`allow_managed_domains_only` on SandboxNetworkConfig**: Added boolean field (defaults `false`), serialized as `allowManagedDomainsOnly` in `to_h`, with RBS signature and tests.
- **`initialization_result()` method**: Added `InitializationResult` type composing `SlashCommand`, `ModelInfo`, and `AccountInfo`. Method sends `supported_commands` request and maps the full response. Delegated through `Client` with RBS signatures and tests.
- **SPEC.md** updated to reflect full v0.2.32 parity with TS v0.2.32 and Python v0.1.30 reference versions.