### PR TITLE
feat: complete SDK parity with TypeScript v0.2.33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `session_id` option for custom conversation UUIDs (`--session-id` CLI flag)
+- `TeammateIdle` hook event with `TeammateIdleInput` (TypeScript SDK v0.2.33 parity)
+- `TaskCompleted` hook event with `TaskCompletedInput` (TypeScript SDK v0.2.33 parity)
+
+### Changed
+- Updated SPEC.md to reflect full TypeScript SDK v0.2.34 parity
+
 ## [0.7.2] - 2026-02-05
 
 ### Added

--- a/SPEC.md
+++ b/SPEC.md
@@ -3,11 +3,11 @@
 This document provides a comprehensive specification of the Claude Agent SDK, comparing feature parity across the official TypeScript and Python SDKs with this Ruby implementation.
 
 **Reference Versions:**
-- TypeScript SDK: v0.2.32 (npm package)
-- Python SDK: v0.1.30 from GitHub (commit 451f2f4)
+- TypeScript SDK: v0.2.34 (npm package)
+- Python SDK: v0.1.31 from GitHub (commit 4b19642)
 - Ruby SDK: This repository
 
-**Last Updated:** 2026-02-05
+**Last Updated:** 2026-02-06
 
 ---
 
@@ -50,6 +50,7 @@ Configuration options for SDK queries and clients.
 | `maxThinkingTokens`               |     ✅      |   ✅    |  ✅   | Max thinking tokens                                          |
 | `continue`                        |     ✅      |   ✅    |  ✅   | Continue most recent conversation                            |
 | `resume`                          |     ✅      |   ✅    |  ✅   | Resume session by ID                                         |
+| `sessionId`                       |     ✅      |   ❌    |  ✅   | Custom UUID for conversations (v0.2.33)                      |
 | `resumeSessionAt`                 |     ✅      |   ❌    |  ✅   | Resume to specific message UUID                              |
 | `forkSession`                     |     ✅      |   ✅    |  ✅   | Fork on resume                                               |
 | `persistSession`                  |     ✅      |   ❌    |  ✅   | Whether to persist to disk                                   |
@@ -230,15 +231,15 @@ Bidirectional control protocol for SDK-CLI communication.
 
 ### Return Types
 
-| Type                  | TypeScript | Python | Ruby | Notes                  |
-|-----------------------|:----------:|:------:|:----:|------------------------|
-| `SlashCommand`        |     ✅      |   ❌    |  ✅   | Available command info |
-| `ModelInfo`           |     ✅      |   ❌    |  ✅   | Model information      |
-| `McpServerStatus`     |     ✅      |   ❌    |  ✅   | MCP server status      |
-| `AccountInfo`         |     ✅      |   ❌    |  ✅   | Account information    |
-| `InitializationResult`|     ✅      |   ❌    |  ✅   | Full init response     |
-| `McpSetServersResult` |     ✅      |   ❌    |  ✅   | Set servers result     |
-| `RewindFilesResult`   |     ✅      |   ✅    |  ✅   | Rewind result          |
+| Type                   | TypeScript | Python | Ruby | Notes                  |
+|------------------------|:----------:|:------:|:----:|------------------------|
+| `SlashCommand`         |     ✅      |   ❌    |  ✅   | Available command info |
+| `ModelInfo`            |     ✅      |   ❌    |  ✅   | Model information      |
+| `McpServerStatus`      |     ✅      |   ❌    |  ✅   | MCP server status      |
+| `AccountInfo`          |     ✅      |   ❌    |  ✅   | Account information    |
+| `InitializationResult` |     ✅      |   ❌    |  ✅   | Full init response     |
+| `McpSetServersResult`  |     ✅      |   ❌    |  ✅   | Set servers result     |
+| `RewindFilesResult`    |     ✅      |   ✅    |  ✅   | Rewind result          |
 
 ---
 
@@ -263,6 +264,8 @@ Event hooks for intercepting and modifying SDK behavior.
 | `PreCompact`         |     ✅      |   ✅    |  ✅   | Before compaction         |
 | `PermissionRequest`  |     ✅      |   ✅    |  ✅   | Permission requested      |
 | `Setup`              |     ✅      |   ❌    |  ✅   | Initial setup/maintenance |
+| `TeammateIdle`       |     ✅      |   ❌    |  ✅   | Teammate idle (v0.2.33)   |
+| `TaskCompleted`      |     ✅      |   ❌    |  ✅   | Task completed (v0.2.33)  |
 
 ### Hook Input Types
 
@@ -281,6 +284,8 @@ Event hooks for intercepting and modifying SDK behavior.
 | `PreCompactHookInput`         |     ✅      |   ✅    |  ✅   |
 | `PermissionRequestHookInput`  |     ✅      |   ✅    |  ✅   |
 | `SetupHookInput`              |     ✅      |   ❌    |  ✅   |
+| `TeammateIdleHookInput`       |     ✅      |   ❌    |  ✅   |
+| `TaskCompletedHookInput`      |     ✅      |   ❌    |  ✅   |
 
 ### Hook Output Types
 
@@ -668,16 +673,16 @@ Public API surface for SDK clients.
 - Full source available
 - Has `Transport` abstract class and several query control methods
 - Query supports: `interrupt()`, `set_permission_mode()`, `set_model()`, `rewind_files()`, `stream_input()`, `close()`, `get_mcp_status()`
-- Client supports: `interrupt()`, `set_permission_mode()`, `set_model()`, `rewind_files()`, `get_mcp_status()`
-- Missing hooks: SessionStart, SessionEnd, Setup
+- Client supports: `interrupt()`, `set_permission_mode()`, `set_model()`, `rewind_files()`, `get_mcp_status()`, `get_server_info()`
+- Missing hooks: SessionStart, SessionEnd, Setup, TeammateIdle, TaskCompleted
 - Missing permission modes: `delegate`, `dontAsk`
-- Missing options: `allowDangerouslySkipPermissions`, `persistSession`, `resumeSessionAt`, `strictMcpConfig`, `init`/`initOnly`/`maintenance`, `debug`/`debugFile`
+- Missing options: `allowDangerouslySkipPermissions`, `persistSession`, `resumeSessionAt`, `sessionId`, `strictMcpConfig`, `init`/`initOnly`/`maintenance`, `debug`/`debugFile`
 - `ToolPermissionContext` missing `blockedPath`, `decisionReason`, `toolUseID`, `agentID`
-- Now has `additionalContext` in `PreToolUseHookSpecificOutput` (added in v0.1.30)
-- Now has `create_sdk_mcp_server`, `tool()` helper, and MCP tool annotations (added in v0.1.30)
+- Has `additionalContext` in `PreToolUseHookSpecificOutput` (added in v0.1.30)
+- Has `create_sdk_mcp_server`, `tool()` helper, and MCP tool annotations (added in v0.1.30/v0.1.31)
 
 ### Ruby SDK (This Repository)
-- Full TypeScript SDK v0.2.32 feature parity
+- Full TypeScript SDK v0.2.34 feature parity (v0.2.34 contains no new SDK features beyond a Claude Code version bump)
 - Ruby-idiomatic patterns (Data.define, snake_case)
 - Complete control protocol, hook, and V2 Session API support
 - Dedicated Client class for multi-turn conversations

--- a/lib/claude_agent/hooks.rb
+++ b/lib/claude_agent/hooks.rb
@@ -16,6 +16,8 @@ module ClaudeAgent
     PreCompact
     PermissionRequest
     Setup
+    TeammateIdle
+    TaskCompleted
   ].freeze
 
   # Matcher configuration for hooks
@@ -257,6 +259,44 @@ module ClaudeAgent
     # @return [Boolean]
     def maintenance?
       trigger == "maintenance"
+    end
+  end
+
+  # Input for TeammateIdle hook (TypeScript SDK v0.2.33 parity)
+  #
+  # Fired when a teammate becomes idle.
+  #
+  class TeammateIdleInput < BaseHookInput
+    attr_reader :teammate_name, :team_name
+
+    # @param teammate_name [String] Name of the idle teammate
+    # @param team_name [String] Name of the team
+    def initialize(teammate_name:, team_name:, **kwargs)
+      super(hook_event_name: "TeammateIdle", **kwargs)
+      @teammate_name = teammate_name
+      @team_name = team_name
+    end
+  end
+
+  # Input for TaskCompleted hook (TypeScript SDK v0.2.33 parity)
+  #
+  # Fired when a task completes.
+  #
+  class TaskCompletedInput < BaseHookInput
+    attr_reader :task_id, :task_subject, :task_description, :teammate_name, :team_name
+
+    # @param task_id [String] ID of the completed task
+    # @param task_subject [String] Subject of the completed task
+    # @param task_description [String, nil] Description of the completed task
+    # @param teammate_name [String, nil] Name of the teammate that completed the task
+    # @param team_name [String, nil] Name of the team
+    def initialize(task_id:, task_subject:, task_description: nil, teammate_name: nil, team_name: nil, **kwargs)
+      super(hook_event_name: "TaskCompleted", **kwargs)
+      @task_id = task_id
+      @task_subject = task_subject
+      @task_description = task_description
+      @teammate_name = teammate_name
+      @team_name = team_name
     end
   end
 end

--- a/lib/claude_agent/options.rb
+++ b/lib/claude_agent/options.rb
@@ -52,7 +52,7 @@ module ClaudeAgent
       system_prompt append_system_prompt
       model fallback_model
       permission_mode permission_prompt_tool_name can_use_tool allow_dangerously_skip_permissions
-      continue_conversation resume fork_session resume_session_at
+      continue_conversation resume fork_session resume_session_at session_id
       max_turns max_budget_usd max_thinking_tokens
       strict_mcp_config mcp_servers hooks
       settings sandbox cwd add_dirs env user agent
@@ -179,6 +179,7 @@ module ClaudeAgent
         args.push("--resume", resume) if resume
         args.push("--fork-session") if fork_session
         args.push("--resume-session-at", resume_session_at) if resume_session_at
+        args.push("--session-id", session_id) if session_id
       end
     end
 
@@ -285,6 +286,10 @@ module ClaudeAgent
 
       if max_budget_usd && (!max_budget_usd.is_a?(Numeric) || max_budget_usd <= 0)
         raise ConfigurationError, "max_budget_usd must be a positive number"
+      end
+
+      if session_id && (continue_conversation || resume) && !fork_session
+        raise ConfigurationError, "session_id cannot be used with continue or resume unless fork_session is also set"
       end
 
       setup_options = [ init, init_only, maintenance ].count { |opt| opt }

--- a/sig/claude_agent.rbs
+++ b/sig/claude_agent.rbs
@@ -265,6 +265,7 @@ module ClaudeAgent
     attr_accessor resume: String?
     attr_accessor fork_session: bool
     attr_accessor resume_session_at: String?
+    attr_accessor session_id: String?
     attr_accessor persist_session: bool
 
     # Limits & budget
@@ -766,6 +767,31 @@ module ClaudeAgent
     attr_reader permission_suggestions: untyped
 
     def initialize: (tool_name: String, tool_input: Hash[String, untyped], ?permission_suggestions: untyped, **untyped) -> void
+  end
+
+  class SetupInput < BaseHookInput
+    attr_reader trigger: String
+
+    def initialize: (trigger: String, **untyped) -> void
+    def init?: () -> bool
+    def maintenance?: () -> bool
+  end
+
+  class TeammateIdleInput < BaseHookInput
+    attr_reader teammate_name: String
+    attr_reader team_name: String
+
+    def initialize: (teammate_name: String, team_name: String, **untyped) -> void
+  end
+
+  class TaskCompletedInput < BaseHookInput
+    attr_reader task_id: String
+    attr_reader task_subject: String
+    attr_reader task_description: String?
+    attr_reader teammate_name: String?
+    attr_reader team_name: String?
+
+    def initialize: (task_id: String, task_subject: String, ?task_description: String?, ?teammate_name: String?, ?team_name: String?, **untyped) -> void
   end
 
   # Permission types

--- a/test/claude_agent/test_hooks.rb
+++ b/test/claude_agent/test_hooks.rb
@@ -334,4 +334,85 @@ class TestClaudeAgentHooks < ActiveSupport::TestCase
   test "setup_event_in_hook_events" do
     assert_includes ClaudeAgent::HOOK_EVENTS, "Setup"
   end
+
+  # --- TeammateIdleInput ---
+
+  test "teammate_idle_event_in_hook_events" do
+    assert_includes ClaudeAgent::HOOK_EVENTS, "TeammateIdle"
+  end
+
+  test "teammate_idle_input" do
+    input = ClaudeAgent::TeammateIdleInput.new(
+      teammate_name: "alice",
+      team_name: "backend-team",
+      session_id: "sess-456"
+    )
+    assert_equal "TeammateIdle", input.hook_event_name
+    assert_equal "alice", input.teammate_name
+    assert_equal "backend-team", input.team_name
+    assert_equal "sess-456", input.session_id
+  end
+
+  test "teammate_idle_input_inherits_base_fields" do
+    input = ClaudeAgent::TeammateIdleInput.new(
+      teammate_name: "bob",
+      team_name: "frontend-team",
+      transcript_path: "/path/to/transcript",
+      cwd: "/home/user",
+      permission_mode: "default"
+    )
+    assert_equal "/path/to/transcript", input.transcript_path
+    assert_equal "/home/user", input.cwd
+    assert_equal "default", input.permission_mode
+  end
+
+  # --- TaskCompletedInput ---
+
+  test "task_completed_event_in_hook_events" do
+    assert_includes ClaudeAgent::HOOK_EVENTS, "TaskCompleted"
+  end
+
+  test "task_completed_input" do
+    input = ClaudeAgent::TaskCompletedInput.new(
+      task_id: "task-789",
+      task_subject: "Fix login bug",
+      task_description: "The login form fails on mobile",
+      teammate_name: "alice",
+      team_name: "backend-team",
+      session_id: "sess-789"
+    )
+    assert_equal "TaskCompleted", input.hook_event_name
+    assert_equal "task-789", input.task_id
+    assert_equal "Fix login bug", input.task_subject
+    assert_equal "The login form fails on mobile", input.task_description
+    assert_equal "alice", input.teammate_name
+    assert_equal "backend-team", input.team_name
+    assert_equal "sess-789", input.session_id
+  end
+
+  test "task_completed_input_with_required_fields_only" do
+    input = ClaudeAgent::TaskCompletedInput.new(
+      task_id: "task-001",
+      task_subject: "Update docs"
+    )
+    assert_equal "TaskCompleted", input.hook_event_name
+    assert_equal "task-001", input.task_id
+    assert_equal "Update docs", input.task_subject
+    assert_nil input.task_description
+    assert_nil input.teammate_name
+    assert_nil input.team_name
+  end
+
+  test "task_completed_input_inherits_base_fields" do
+    input = ClaudeAgent::TaskCompletedInput.new(
+      task_id: "task-002",
+      task_subject: "Deploy service",
+      transcript_path: "/path/to/transcript",
+      cwd: "/home/user",
+      permission_mode: "acceptEdits"
+    )
+    assert_equal "/path/to/transcript", input.transcript_path
+    assert_equal "/home/user", input.cwd
+    assert_equal "acceptEdits", input.permission_mode
+  end
 end

--- a/test/claude_agent/test_options.rb
+++ b/test/claude_agent/test_options.rb
@@ -418,6 +418,61 @@ class TestClaudeAgentOptions < ActiveSupport::TestCase
     assert_match(/Only one of init, init_only, or maintenance/, error.message)
   end
 
+  # --- Session ID ---
+
+  test "session_id_option_default_nil" do
+    options = ClaudeAgent::Options.new
+    assert_nil options.session_id
+  end
+
+  test "session_id_option_with_value" do
+    options = ClaudeAgent::Options.new(session_id: "custom-uuid-123")
+    assert_equal "custom-uuid-123", options.session_id
+  end
+
+  test "to_cli_args_with_session_id" do
+    options = ClaudeAgent::Options.new(session_id: "my-session")
+    args = options.to_cli_args
+    assert_includes args, "--session-id"
+    assert_includes args, "my-session"
+  end
+
+  test "to_cli_args_without_session_id" do
+    options = ClaudeAgent::Options.new
+    args = options.to_cli_args
+    refute_includes args, "--session-id"
+  end
+
+  test "session_id_with_continue_raises_without_fork" do
+    assert_raises(ClaudeAgent::ConfigurationError) do
+      ClaudeAgent::Options.new(session_id: "abc", continue_conversation: true)
+    end
+  end
+
+  test "session_id_with_resume_raises_without_fork" do
+    assert_raises(ClaudeAgent::ConfigurationError) do
+      ClaudeAgent::Options.new(session_id: "abc", resume: "sess-123")
+    end
+  end
+
+  test "session_id_with_continue_and_fork_is_valid" do
+    options = ClaudeAgent::Options.new(
+      session_id: "abc",
+      continue_conversation: true,
+      fork_session: true
+    )
+    assert_equal "abc", options.session_id
+  end
+
+  test "session_id_with_resume_and_fork_is_valid" do
+    options = ClaudeAgent::Options.new(
+      session_id: "abc",
+      resume: "sess-123",
+      fork_session: true
+    )
+    assert_equal "abc", options.session_id
+  end
+
   # --- Debug Options ---
 
   test "debug_option_default_false" do


### PR DESCRIPTION
## What
Implements the 3 remaining features from TypeScript SDK v0.2.33 to achieve full parity through v0.2.34.

## Why
The Ruby SDK had parity with TS v0.2.32 but was missing `sessionId`, `TeammateIdle`, and `TaskCompleted` from v0.2.33. Note: v0.2.34 contains no new SDK features (only a Claude Code version bump).

## How
- **`session_id` option** — New attribute on `Options` with `--session-id` CLI arg mapping and validation (cannot combine with `continue`/`resume` unless `fork_session` is set)
- **`TeammateIdle` hook event** — New `TeammateIdleInput` class with `teammate_name` and `team_name` fields
- **`TaskCompleted` hook event** — New `TaskCompletedInput` class with `task_id`, `task_subject`, `task_description`, `teammate_name`, and `team_name` fields
- RBS type signatures for all new types (plus missing `SetupInput`)
- SPEC.md updated to reflect full v0.2.34 parity
