### PR TITLE
feat: add thinking, effort options and max_output_tokens error type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `thinking` option for controlling extended thinking mode (`{ type: "adaptive" }`, `{ type: "enabled", budgetTokens: N }`, `{ type: "disabled" }`)
+- `effort` option for response effort level (`"low"`, `"medium"`, `"high"`, `"max"`)
+- `max_output_tokens` assistant message error type
+
 ## [0.7.4] - 2026-02-07
 
 ### Added

--- a/SPEC.md
+++ b/SPEC.md
@@ -3,11 +3,11 @@
 This document provides a comprehensive specification of the Claude Agent SDK, comparing feature parity across the official TypeScript and Python SDKs with this Ruby implementation.
 
 **Reference Versions:**
-- TypeScript SDK: v0.2.34 (npm package)
-- Python SDK: v0.1.31 from GitHub (commit 4b19642)
+- TypeScript SDK: v0.2.38 (npm package)
+- Python SDK: v0.1.34 from GitHub (commit a969042)
 - Ruby SDK: This repository
 
-**Last Updated:** 2026-02-07
+**Last Updated:** 2026-02-09
 
 ---
 
@@ -47,7 +47,9 @@ Configuration options for SDK queries and clients.
 | `permissionPromptToolName`        |     ✅      |   ✅    |  ✅   | MCP tool for permission prompts                              |
 | `maxTurns`                        |     ✅      |   ✅    |  ✅   | Max conversation turns                                       |
 | `maxBudgetUsd`                    |     ✅      |   ✅    |  ✅   | Max USD budget                                               |
-| `maxThinkingTokens`               |     ✅      |   ✅    |  ✅   | Max thinking tokens                                          |
+| `thinking`                        |     ✅      |   ❌    |  ✅   | Thinking mode config (adaptive/enabled/disabled) (v0.2.35+)  |
+| `effort`                          |     ✅      |   ❌    |  ✅   | Response effort level (low/medium/high/max) (v0.2.35+)       |
+| `maxThinkingTokens`               |     ✅      |   ✅    |  ✅   | Max thinking tokens (deprecated in TS, use `thinking`)       |
 | `continue`                        |     ✅      |   ✅    |  ✅   | Continue most recent conversation                            |
 | `resume`                          |     ✅      |   ✅    |  ✅   | Resume session by ID                                         |
 | `sessionId`                       |     ✅      |   ❌    |  ✅   | Custom UUID for conversations (v0.2.33)                      |
@@ -595,6 +597,7 @@ Error types and hierarchy.
 | `invalid_request`       |     ✅      |   ✅    |  ✅   |
 | `server_error`          |     ✅      |   ✅    |  ✅   |
 | `unknown`               |     ✅      |   ✅    |  ✅   |
+| `max_output_tokens`     |     ✅      |   ❌    |  ✅   |
 
 ---
 
@@ -674,12 +677,12 @@ Public API surface for SDK clients.
 - Partial control protocol: query and client support interrupt, setPermissionMode, setModel, rewindFiles, mcpStatus
 - Missing hooks: SessionStart, SessionEnd, Setup, TeammateIdle, TaskCompleted
 - Missing permission modes: `delegate`, `dontAsk`
-- Missing options: `allowDangerouslySkipPermissions`, `persistSession`, `resumeSessionAt`, `sessionId`, `strictMcpConfig`, `init`/`initOnly`/`maintenance`, `debug`/`debugFile`
+- Missing options: `thinking`, `effort`, `allowDangerouslySkipPermissions`, `persistSession`, `resumeSessionAt`, `sessionId`, `strictMcpConfig`, `init`/`initOnly`/`maintenance`, `debug`/`debugFile`
 - `ToolPermissionContext` missing `blockedPath`, `decisionReason`, `toolUseID`, `agentID`, `description`
 - Has SDK MCP server support with `tool()` helper and annotations
 
 ### Ruby SDK (This Repository)
-- Full TypeScript SDK v0.2.34 feature parity (v0.2.34 contains no new SDK features beyond a Claude Code version bump)
+- Feature parity with TypeScript SDK v0.2.38
 - Ruby-idiomatic patterns (Data.define, snake_case)
 - Complete control protocol, hook, and V2 Session API support
 - Dedicated Client class for multi-turn conversations

--- a/lib/claude_agent/options.rb
+++ b/lib/claude_agent/options.rb
@@ -47,13 +47,16 @@ module ClaudeAgent
     }.freeze
 
     # All configurable attributes
+    # Valid effort levels for the effort option
+    EFFORT_LEVELS = %w[low medium high max].freeze
+
     ATTRIBUTES = %i[
       tools allowed_tools disallowed_tools
       system_prompt append_system_prompt
       model fallback_model
       permission_mode permission_prompt_tool_name can_use_tool allow_dangerously_skip_permissions
       continue_conversation resume fork_session resume_session_at session_id
-      max_turns max_budget_usd max_thinking_tokens
+      max_turns max_budget_usd thinking effort max_thinking_tokens
       strict_mcp_config mcp_servers hooks
       settings sandbox cwd add_dirs env user agent
       cli_path extra_args agents setting_sources plugins
@@ -194,8 +197,26 @@ module ClaudeAgent
       [].tap do |args|
         args.push("--max-turns", max_turns.to_s) if max_turns
         args.push("--max-budget-usd", max_budget_usd.to_s) if max_budget_usd
-        args.push("--max-thinking-tokens", max_thinking_tokens.to_s) if max_thinking_tokens
+        args.concat(thinking_args)
+        args.push("--max-thinking-tokens", max_thinking_tokens.to_s) if !thinking && max_thinking_tokens
+        args.push("--effort", effort) if effort
         args.push("--strict-mcp-config") if strict_mcp_config
+      end
+    end
+
+    def thinking_args
+      return [] unless thinking.is_a?(Hash)
+
+      type = thinking[:type] || thinking["type"]
+      case type
+      when "disabled"
+        [ "--max-thinking-tokens", "0" ]
+      when "enabled"
+        budget = thinking[:budgetTokens] || thinking[:budget_tokens] ||
+                 thinking["budgetTokens"] || thinking["budget_tokens"]
+        budget ? [ "--max-thinking-tokens", budget.to_s ] : []
+      else # "adaptive" or unrecognized — omit flag, let CLI use default
+        []
       end
     end
 
@@ -299,6 +320,20 @@ module ClaudeAgent
 
       if max_budget_usd && (!max_budget_usd.is_a?(Numeric) || max_budget_usd <= 0)
         raise ConfigurationError, "max_budget_usd must be a positive number"
+      end
+
+      if thinking
+        unless thinking.is_a?(Hash)
+          raise ConfigurationError, "thinking must be a Hash with :type key (e.g., { type: 'adaptive' })"
+        end
+        type = thinking[:type] || thinking["type"]
+        unless %w[adaptive enabled disabled].include?(type)
+          raise ConfigurationError, "thinking[:type] must be one of: adaptive, enabled, disabled"
+        end
+      end
+
+      if effort && !EFFORT_LEVELS.include?(effort)
+        raise ConfigurationError, "Invalid effort: #{effort}. Must be one of: #{EFFORT_LEVELS.join(", ")}"
       end
 
       if session_id && (continue_conversation || resume) && !fork_session

--- a/lib/claude_agent/types.rb
+++ b/lib/claude_agent/types.rb
@@ -10,6 +10,7 @@ module ClaudeAgent
     invalid_request
     server_error
     unknown
+    max_output_tokens
   ].freeze
 
   # API key source types (TypeScript SDK parity)

--- a/sig/claude_agent.rbs
+++ b/sig/claude_agent.rbs
@@ -262,6 +262,7 @@ module ClaudeAgent
     # Constants
     DEFAULTS: Hash[Symbol, untyped]
     ATTRIBUTES: Array[Symbol]
+    EFFORT_LEVELS: Array[String]
 
     # Tool configuration
     attr_accessor tools: (Array[String] | String)?
@@ -293,6 +294,8 @@ module ClaudeAgent
     # Limits & budget
     attr_accessor max_turns: Integer?
     attr_accessor max_budget_usd: Float?
+    attr_accessor thinking: Hash[Symbol | String, untyped]?
+    attr_accessor effort: String?
     attr_accessor max_thinking_tokens: Integer?
 
     # Strict validation

--- a/test/claude_agent/test_options.rb
+++ b/test/claude_agent/test_options.rb
@@ -505,6 +505,129 @@ class TestClaudeAgentOptions < ActiveSupport::TestCase
     assert_equal "abc", options.session_id
   end
 
+  # --- Thinking Option ---
+
+  test "thinking_option_default_nil" do
+    options = ClaudeAgent::Options.new
+    assert_nil options.thinking
+  end
+
+  test "thinking_option_adaptive" do
+    options = ClaudeAgent::Options.new(thinking: { type: "adaptive" })
+    assert_equal({ type: "adaptive" }, options.thinking)
+  end
+
+  test "thinking_option_enabled_with_budget" do
+    options = ClaudeAgent::Options.new(thinking: { type: "enabled", budgetTokens: 10_000 })
+    assert_equal({ type: "enabled", budgetTokens: 10_000 }, options.thinking)
+  end
+
+  test "thinking_option_disabled" do
+    options = ClaudeAgent::Options.new(thinking: { type: "disabled" })
+    assert_equal({ type: "disabled" }, options.thinking)
+  end
+
+  test "thinking_option_with_string_keys" do
+    options = ClaudeAgent::Options.new(thinking: { "type" => "adaptive" })
+    assert_equal({ "type" => "adaptive" }, options.thinking)
+  end
+
+  test "thinking_option_invalid_type_raises" do
+    assert_raises(ClaudeAgent::ConfigurationError) do
+      ClaudeAgent::Options.new(thinking: { type: "invalid" })
+    end
+  end
+
+  test "thinking_option_non_hash_raises" do
+    assert_raises(ClaudeAgent::ConfigurationError) do
+      ClaudeAgent::Options.new(thinking: "adaptive")
+    end
+  end
+
+  test "to_cli_args_thinking_adaptive_omits_flag" do
+    options = ClaudeAgent::Options.new(thinking: { type: "adaptive" })
+    args = options.to_cli_args
+    refute_includes args, "--max-thinking-tokens"
+  end
+
+  test "to_cli_args_thinking_enabled_sets_budget" do
+    options = ClaudeAgent::Options.new(thinking: { type: "enabled", budgetTokens: 8000 })
+    args = options.to_cli_args
+    assert_includes args, "--max-thinking-tokens"
+    idx = args.index("--max-thinking-tokens")
+    assert_equal "8000", args[idx + 1]
+  end
+
+  test "to_cli_args_thinking_enabled_with_snake_case_key" do
+    options = ClaudeAgent::Options.new(thinking: { type: "enabled", budget_tokens: 5000 })
+    args = options.to_cli_args
+    assert_includes args, "--max-thinking-tokens"
+    idx = args.index("--max-thinking-tokens")
+    assert_equal "5000", args[idx + 1]
+  end
+
+  test "to_cli_args_thinking_disabled_sets_zero" do
+    options = ClaudeAgent::Options.new(thinking: { type: "disabled" })
+    args = options.to_cli_args
+    assert_includes args, "--max-thinking-tokens"
+    idx = args.index("--max-thinking-tokens")
+    assert_equal "0", args[idx + 1]
+  end
+
+  test "thinking_takes_precedence_over_max_thinking_tokens" do
+    options = ClaudeAgent::Options.new(
+      thinking: { type: "disabled" },
+      max_thinking_tokens: 10_000
+    )
+    args = options.to_cli_args
+    # thinking should produce --max-thinking-tokens 0, and the standalone max_thinking_tokens should be suppressed
+    token_indices = args.each_index.select { |i| args[i] == "--max-thinking-tokens" }
+    assert_equal 1, token_indices.size
+    assert_equal "0", args[token_indices.first + 1]
+  end
+
+  test "max_thinking_tokens_used_when_thinking_not_set" do
+    options = ClaudeAgent::Options.new(max_thinking_tokens: 5000)
+    args = options.to_cli_args
+    assert_includes args, "--max-thinking-tokens"
+    idx = args.index("--max-thinking-tokens")
+    assert_equal "5000", args[idx + 1]
+  end
+
+  # --- Effort Option ---
+
+  test "effort_option_default_nil" do
+    options = ClaudeAgent::Options.new
+    assert_nil options.effort
+  end
+
+  test "effort_option_valid_values" do
+    %w[low medium high max].each do |level|
+      options = ClaudeAgent::Options.new(effort: level)
+      assert_equal level, options.effort
+    end
+  end
+
+  test "effort_option_invalid_raises" do
+    assert_raises(ClaudeAgent::ConfigurationError) do
+      ClaudeAgent::Options.new(effort: "extreme")
+    end
+  end
+
+  test "to_cli_args_with_effort" do
+    options = ClaudeAgent::Options.new(effort: "high")
+    args = options.to_cli_args
+    assert_includes args, "--effort"
+    idx = args.index("--effort")
+    assert_equal "high", args[idx + 1]
+  end
+
+  test "to_cli_args_without_effort" do
+    options = ClaudeAgent::Options.new
+    args = options.to_cli_args
+    refute_includes args, "--effort"
+  end
+
   # --- Debug Options ---
 
   test "debug_option_default_false" do


### PR DESCRIPTION
## What
Add `thinking`, `effort` options and `max_output_tokens` assistant message error type to achieve full feature parity with TypeScript SDK v0.2.38.

## Why
The TypeScript SDK added these features in v0.2.35+. This brings the Ruby SDK up to date.

## How
- **`thinking` option**: Accepts `{ type: "adaptive" }`, `{ type: "enabled", budgetTokens: N }`, or `{ type: "disabled" }`. Maps to `--max-thinking-tokens` CLI flag (adaptive omits flag, enabled passes budget, disabled passes 0). Takes precedence over deprecated `max_thinking_tokens` when both set.
- **`effort` option**: Accepts `"low"`, `"medium"`, `"high"`, or `"max"`. Maps to `--effort` CLI flag. Validated against `EFFORT_LEVELS` constant.
- **`max_output_tokens` error type**: Added to `ASSISTANT_MESSAGE_ERROR_TYPES` constant.
- Updated RBS signatures, SPEC.md parity markers, and 17 new unit tests.