### PR TITLE
Add .worktreeinclude for fr8 worktree sync

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,13 @@
+# Files to copy to new worktrees (must also be in .gitignore)
+
+# Claude Configs
+.claude/settings.local.json
+.claude/**/local-*
+.claude/**/local/
+
+# MCP server configuration
+.mcp.json
+
+# Local dependencies and temp files
+/tmp/**
+/vendor/**


### PR DESCRIPTION
## What
Adds a `.worktreeinclude` file so fr8 worktrees automatically get copies of gitignored files needed for development.

## Why
Without this, new worktrees are missing local Claude configs, MCP server configuration, vendored dependencies, and temp files — requiring manual setup each time.

## Included patterns
- `.claude/settings.local.json`, `.claude/**/local-*`, `.claude/**/local/`
- `.mcp.json`
- `/tmp/**`, `/vendor/**`