### PR TITLE
feat: implement TypeScript SDK v0.2.43-v0.2.49 feature parity

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -3,11 +3,11 @@
 This document provides a comprehensive specification of the Claude Agent SDK, comparing feature parity across the official TypeScript and Python SDKs with this Ruby implementation.
 
 **Reference Versions:**
-- TypeScript SDK: v0.2.42 (npm package)
-- Python SDK: v0.1.36 from GitHub (commit 4d74748)
+- TypeScript SDK: v0.2.49 (npm package)
+- Python SDK: v0.1.39 from GitHub (commit 146e3d6)
 - Ruby SDK: This repository
 
-**Last Updated:** 2026-02-13
+**Last Updated:** 2026-02-20
 
 ---
 
@@ -41,7 +41,7 @@ Configuration options for SDK queries and clients.
 | `tools`                           |     ✅      |   ✅    |  ✅   | Array or preset                                              |
 | `allowedTools`                    |     ✅      |   ✅    |  ✅   | Auto-allowed tools                                           |
 | `disallowedTools`                 |     ✅      |   ✅    |  ✅   | Blocked tools                                                |
-| `permissionMode`                  |     ✅      |   ✅    |  ✅   | default/acceptEdits/plan/bypassPermissions/delegate/dontAsk  |
+| `permissionMode`                  |     ✅      |   ✅    |  ✅   | default/acceptEdits/plan/bypassPermissions/dontAsk           |
 | `allowDangerouslySkipPermissions` |     ✅      |   ❌    |  ✅   | Required for bypassPermissions                               |
 | `canUseTool`                      |     ✅      |   ✅    |  ✅   | Permission callback                                          |
 | `permissionPromptToolName`        |     ✅      |   ✅    |  ✅   | MCP tool for permission prompts                              |
@@ -83,6 +83,7 @@ Configuration options for SDK queries and clients.
 | `init`                            |     ✅      |   ❌    |  ✅   | Run Setup hooks (init trigger), then continue (hidden CLI)   |
 | `initOnly`                        |     ✅      |   ❌    |  ✅   | Run Setup hooks (init trigger), then exit (hidden CLI)       |
 | `maintenance`                     |     ✅      |   ❌    |  ✅   | Run Setup hooks (maintenance trigger), continue (hidden CLI) |
+| `promptSuggestions`               |     ✅      |   ❌    |  ✅   | Enable prompt suggestion after each turn (v0.2.47)           |
 | `debug`                           |     ✅      |   ❌    |  ✅   | Enable verbose debug logging                                 |
 | `debugFile`                       |     ✅      |   ❌    |  ✅   | Write debug logs to specific file path                       |
 
@@ -109,6 +110,9 @@ Messages exchanged between SDK and CLI.
 | `AuthStatusMessage`       |     ✅      |   ❌    |  ✅   | Authentication status              |
 | `TaskNotificationMessage` |     ✅      |   ❌    |  ✅   | Background task completion         |
 | `ToolUseSummaryMessage`   |     ✅      |   ❌    |  ✅   | Summary of tool use (collapsed)    |
+| `TaskStartedMessage`      |     ✅      |   ❌    |  ✅   | Subagent task registered (v0.2.45) |
+| `RateLimitEvent`          |     ✅      |   ❌    |  ✅   | Rate limit status changes          |
+| `PromptSuggestionMessage` |     ✅      |   ❌    |  ✅   | Suggested next prompt (v0.2.47)    |
 | `FilesPersistedEvent`     |     ✅      |   ❌    |  ✅   | File persistence confirmation      |
 
 ### Message Fields
@@ -269,6 +273,7 @@ Event hooks for intercepting and modifying SDK behavior.
 | `Setup`              |     ✅      |   ❌    |  ✅   | Initial setup/maintenance         |
 | `TeammateIdle`       |     ✅      |   ❌    |  ✅   | Teammate idle (v0.2.33)           |
 | `TaskCompleted`      |     ✅      |   ❌    |  ✅   | Task completed (v0.2.33)          |
+| `ConfigChange`       |     ✅      |   ❌    |  ✅   | Config file changed (v0.2.49)     |
 
 ### Hook Input Types
 
@@ -289,6 +294,7 @@ Event hooks for intercepting and modifying SDK behavior.
 | `SetupHookInput`              |     ✅      |   ❌    |  ✅   |
 | `TeammateIdleHookInput`       |     ✅      |   ❌    |  ✅   |
 | `TaskCompletedHookInput`      |     ✅      |   ❌    |  ✅   |
+| `ConfigChangeHookInput`       |     ✅      |   ❌    |  ✅   |
 
 ### Hook Output Types
 
@@ -388,7 +394,6 @@ Permission handling and updates.
 | `acceptEdits`       |     ✅      |   ✅    |  ✅   | Auto-accept edits  |
 | `plan`              |     ✅      |   ✅    |  ✅   | Planning mode      |
 | `bypassPermissions` |     ✅      |   ✅    |  ✅   | Skip all checks    |
-| `delegate`          |     ✅      |   ❌    |  ✅   | Delegate mode      |
 | `dontAsk`           |     ✅      |   ❌    |  ✅   | Never prompt       |
 
 ### Permission Result Types
@@ -556,6 +561,15 @@ Sandbox configuration for command execution isolation.
 | `ignoreViolations`          |     ✅      |   ✅    |  ✅   |
 | `enableWeakerNestedSandbox` |     ✅      |   ✅    |  ✅   |
 | `ripgrep`                   |     ✅      |   ❌    |  ✅   |
+| `filesystem`                |     ✅      |   ❌    |  ✅   |
+
+### SandboxFilesystemConfig
+
+| Field        | TypeScript | Python | Ruby |
+|--------------|:----------:|:------:|:----:|
+| `allowWrite` |     ✅      |   ❌    |  ✅   |
+| `denyWrite`  |     ✅      |   ❌    |  ✅   |
+| `denyRead`   |     ✅      |   ❌    |  ✅   |
 
 ### SandboxNetworkConfig
 
@@ -673,20 +687,25 @@ Public API surface for SDK clients.
 - Source is bundled/minified, but `sdk.d.ts` provides complete type definitions
 - Includes unstable V2 session API
 - `executable`/`executableArgs` are JS-specific (`node`/`bun`/`deno`)
+- v0.2.45: Added `TaskStartedMessage`, `RateLimitEvent` message types
+- v0.2.47: Added `promptSuggestions` option and `PromptSuggestionMessage`
+- v0.2.49: Added `ConfigChange` hook event, `SandboxFilesystemConfig`
 
 ### Python SDK
 - Full source available with `Transport` abstract class
 - Partial control protocol: query and client support interrupt, setPermissionMode, setModel, rewindFiles, mcpStatus
-- Missing hooks: SessionStart, SessionEnd, Setup, TeammateIdle, TaskCompleted
-- Missing permission modes: `delegate`, `dontAsk`
-- Missing options: `allowDangerouslySkipPermissions`, `persistSession`, `resumeSessionAt`, `sessionId`, `strictMcpConfig`, `init`/`initOnly`/`maintenance`, `debug`/`debugFile`
+- Missing hooks: SessionStart, SessionEnd, Setup, TeammateIdle, TaskCompleted, ConfigChange
+- Missing permission modes: `dontAsk`
+- Missing options: `allowDangerouslySkipPermissions`, `persistSession`, `resumeSessionAt`, `sessionId`, `strictMcpConfig`, `init`/`initOnly`/`maintenance`, `debug`/`debugFile`, `promptSuggestions`
 - `ToolPermissionContext` missing `blockedPath`, `decisionReason`, `toolUseID`, `agentID`, `description`
 - Has SDK MCP server support with `tool()` helper and annotations
 - Added `thinking` config and `effort` option in v0.1.36
+- Handles `rate_limit_event` and unknown message types gracefully (v0.1.39)
 
 ### Ruby SDK (This Repository)
-- Full feature parity with TypeScript SDK v0.2.42
+- Feature parity with TypeScript SDK v0.2.42
 - Ruby-idiomatic patterns (Data.define, snake_case)
 - Complete control protocol, hook, and V2 Session API support
 - Dedicated Client class for multi-turn conversations
 - `executable`/`executableArgs` marked N/A (JS runtime options)
+- Gaps from TS v0.2.43-v0.2.49: `promptSuggestions`, `TaskStartedMessage`, `RateLimitEvent`, `PromptSuggestionMessage`, `ConfigChange` hook, `SandboxFilesystemConfig`

--- a/lib/claude_agent/control_protocol.rb
+++ b/lib/claude_agent/control_protocol.rb
@@ -532,6 +532,7 @@ module ClaudeAgent
 
       request = { subtype: "initialize" }
       request[:hooks] = hooks_config if hooks_config
+      request[:promptSuggestions] = true if options.prompt_suggestions
 
       send_control_request(**request)
     end

--- a/lib/claude_agent/hooks.rb
+++ b/lib/claude_agent/hooks.rb
@@ -18,6 +18,7 @@ module ClaudeAgent
     Setup
     TeammateIdle
     TaskCompleted
+    ConfigChange
   ].freeze
 
   # Matcher configuration for hooks
@@ -275,6 +276,31 @@ module ClaudeAgent
       super(hook_event_name: "TeammateIdle", **kwargs)
       @teammate_name = teammate_name
       @team_name = team_name
+    end
+  end
+
+  # Input for ConfigChange hook (TypeScript SDK v0.2.49 parity)
+  #
+  # Fired when a configuration file changes.
+  #
+  # @example
+  #   input = ConfigChangeInput.new(
+  #     source: "user_settings",
+  #     file_path: "~/.claude/settings.json",
+  #     session_id: "sess-123"
+  #   )
+  #
+  class ConfigChangeInput < BaseHookInput
+    attr_reader :source, :file_path
+
+    SOURCES = %w[user_settings project_settings local_settings policy_settings skills].freeze
+
+    # @param source [String] One of SOURCES
+    # @param file_path [String, nil] Path to the changed file
+    def initialize(source:, file_path: nil, **kwargs)
+      super(hook_event_name: "ConfigChange", **kwargs)
+      @source = source
+      @file_path = file_path
     end
   end
 

--- a/lib/claude_agent/message_parser.rb
+++ b/lib/claude_agent/message_parser.rb
@@ -16,7 +16,7 @@ module ClaudeAgent
     # Parse a raw message hash into a typed message object
     #
     # @param raw [Hash] Raw message from CLI
-    # @return [UserMessage, UserMessageReplay, AssistantMessage, SystemMessage, ResultMessage, StreamEvent, CompactBoundaryMessage, StatusMessage, ToolProgressMessage, HookResponseMessage, AuthStatusMessage, TaskNotificationMessage, HookStartedMessage, HookProgressMessage, ToolUseSummaryMessage, FilesPersistedEvent]
+    # @return [UserMessage, UserMessageReplay, AssistantMessage, SystemMessage, ResultMessage, StreamEvent, CompactBoundaryMessage, StatusMessage, ToolProgressMessage, HookResponseMessage, AuthStatusMessage, TaskNotificationMessage, HookStartedMessage, HookProgressMessage, ToolUseSummaryMessage, FilesPersistedEvent, TaskStartedMessage, RateLimitEvent, PromptSuggestionMessage]
     # @raise [MessageParseError] If message cannot be parsed
     def parse(raw)
       type = raw["type"]
@@ -44,6 +44,8 @@ module ClaudeAgent
           parse_hook_progress_message(raw)
         when "files_persisted"
           parse_files_persisted_event(raw)
+        when "task_started"
+          parse_task_started_message(raw)
         else
           parse_system_message(raw)
         end
@@ -57,6 +59,10 @@ module ClaudeAgent
         parse_auth_status_message(raw)
       when "tool_use_summary"
         parse_tool_use_summary_message(raw)
+      when "rate_limit_event"
+        parse_rate_limit_event(raw)
+      when "prompt_suggestion"
+        parse_prompt_suggestion_message(raw)
       else
         logger.error("parser") { "Unknown message type: #{type}" }
         raise MessageParseError.new("Unknown message type: #{type}", raw_message: raw)
@@ -334,6 +340,33 @@ module ClaudeAgent
         files: raw["files"] || [],
         failed: raw["failed"] || [],
         processed_at: fetch_dual(raw, :processed_at)
+      )
+    end
+
+    def parse_task_started_message(raw)
+      TaskStartedMessage.new(
+        uuid: raw["uuid"] || "",
+        session_id: fetch_dual(raw, :session_id, ""),
+        task_id: fetch_dual(raw, :task_id, ""),
+        tool_use_id: fetch_dual(raw, :tool_use_id),
+        description: raw["description"],
+        task_type: fetch_dual(raw, :task_type)
+      )
+    end
+
+    def parse_rate_limit_event(raw)
+      RateLimitEvent.new(
+        rate_limit_info: fetch_dual(raw, :rate_limit_info, {}),
+        uuid: raw["uuid"] || "",
+        session_id: fetch_dual(raw, :session_id, "")
+      )
+    end
+
+    def parse_prompt_suggestion_message(raw)
+      PromptSuggestionMessage.new(
+        uuid: raw["uuid"] || "",
+        session_id: fetch_dual(raw, :session_id, ""),
+        suggestion: raw["suggestion"] || ""
       )
     end
   end

--- a/lib/claude_agent/messages.rb
+++ b/lib/claude_agent/messages.rb
@@ -616,6 +616,100 @@ module ClaudeAgent
     end
   end
 
+  # Task started message (TypeScript SDK v0.2.45 parity)
+  #
+  # Sent when a new task (subagent) is started.
+  #
+  # @example
+  #   msg = TaskStartedMessage.new(
+  #     uuid: "msg-123",
+  #     session_id: "session-abc",
+  #     task_id: "task-456",
+  #     tool_use_id: "tool-789",
+  #     description: "Running tests",
+  #     task_type: "bash"
+  #   )
+  #
+  TaskStartedMessage = Data.define(
+    :uuid,
+    :session_id,
+    :task_id,
+    :tool_use_id,
+    :description,
+    :task_type
+  ) do
+    def initialize(
+      uuid:,
+      session_id:,
+      task_id:,
+      tool_use_id: nil,
+      description: nil,
+      task_type: nil
+    )
+      super
+    end
+
+    def type
+      :task_started
+    end
+  end
+
+  # Rate limit event (TypeScript SDK v0.2.45 parity)
+  #
+  # Reports rate limit status and utilization information.
+  #
+  # @example
+  #   msg = RateLimitEvent.new(
+  #     uuid: "msg-123",
+  #     session_id: "session-abc",
+  #     rate_limit_info: {
+  #       "status" => "allowed_warning",
+  #       "resetsAt" => 1700000000,
+  #       "rateLimitType" => "five_hour",
+  #       "utilization" => 0.85,
+  #       "isUsingOverage" => false,
+  #       "overageStatus" => "available"
+  #     }
+  #   )
+  #   msg.status  # => "allowed_warning"
+  #
+  RateLimitEvent = Data.define(:rate_limit_info, :uuid, :session_id) do
+    def initialize(rate_limit_info:, uuid: nil, session_id: nil)
+      super
+    end
+
+    def type
+      :rate_limit_event
+    end
+
+    # Get the rate limit status
+    # @return [String, nil]
+    def status
+      rate_limit_info["status"] || rate_limit_info[:status]
+    end
+  end
+
+  # Prompt suggestion message (TypeScript SDK v0.2.47 parity)
+  #
+  # Contains a suggested prompt for the user.
+  #
+  # @example
+  #   msg = PromptSuggestionMessage.new(
+  #     uuid: "msg-123",
+  #     session_id: "session-abc",
+  #     suggestion: "Tell me about this project"
+  #   )
+  #
+  PromptSuggestionMessage = Data.define(:uuid, :session_id, :suggestion) do
+    def initialize(uuid: nil, session_id: nil, suggestion:)
+      super
+    end
+
+    def type
+      :prompt_suggestion
+    end
+  end
+
   # Files persisted event (TypeScript SDK v0.2.25 parity)
   #
   # Sent when files are persisted to storage during a session.
@@ -670,6 +764,9 @@ module ClaudeAgent
     HookStartedMessage,
     HookProgressMessage,
     ToolUseSummaryMessage,
-    FilesPersistedEvent
+    FilesPersistedEvent,
+    TaskStartedMessage,
+    RateLimitEvent,
+    PromptSuggestionMessage
   ].freeze
 end

--- a/lib/claude_agent/options.rb
+++ b/lib/claude_agent/options.rb
@@ -4,7 +4,7 @@ require "json"
 
 module ClaudeAgent
   # Permission modes for tool execution (TypeScript SDK parity)
-  PERMISSION_MODES = %w[default acceptEdits plan bypassPermissions delegate dontAsk].freeze
+  PERMISSION_MODES = %w[default acceptEdits plan bypassPermissions dontAsk].freeze
 
   # Configuration options for ClaudeAgent queries and clients
   #
@@ -42,6 +42,7 @@ module ClaudeAgent
       init: false,
       init_only: false,
       maintenance: false,
+      prompt_suggestions: false,
       debug: false,
       debug_file: nil
     }.freeze
@@ -61,7 +62,7 @@ module ClaudeAgent
       settings sandbox cwd add_dirs env user agent
       cli_path extra_args agents setting_sources plugins
       include_partial_messages output_format enable_file_checkpointing
-      persist_session betas max_buffer_size stderr_callback
+      persist_session prompt_suggestions betas max_buffer_size stderr_callback
       abort_controller spawn_claude_code_process
       init init_only maintenance
       debug debug_file
@@ -260,6 +261,7 @@ module ClaudeAgent
         args.push("--no-persist-session") if persist_session == false
         args.push("--json-schema", JSON.generate(output_format)) if output_format
         args.push("--include-partial-messages") if include_partial_messages
+        args.push("--prompt-suggestions") if prompt_suggestions
         if agents
           agents_hash = agents.transform_values(&:to_h)
           args.push("--agents", JSON.generate(agents_hash))

--- a/lib/claude_agent/sandbox_settings.rb
+++ b/lib/claude_agent/sandbox_settings.rb
@@ -85,6 +85,29 @@ module ClaudeAgent
     end
   end
 
+  # Filesystem-specific configuration for sandbox mode (TypeScript SDK v0.2.49 parity)
+  #
+  # @example
+  #   filesystem = SandboxFilesystemConfig.new(
+  #     allow_write: ["/tmp/*"],
+  #     deny_write: ["/etc/*"],
+  #     deny_read: ["/secrets/*"]
+  #   )
+  #
+  SandboxFilesystemConfig = Data.define(:allow_write, :deny_write, :deny_read) do
+    def initialize(allow_write: [], deny_write: [], deny_read: [])
+      super
+    end
+
+    def to_h
+      result = {}
+      result[:allowWrite] = allow_write unless allow_write.empty?
+      result[:denyWrite] = deny_write unless deny_write.empty?
+      result[:denyRead] = deny_read unless deny_read.empty?
+      result
+    end
+  end
+
   # Sandbox configuration for command execution (TypeScript SDK parity)
   #
   # @example Basic sandbox
@@ -112,7 +135,8 @@ module ClaudeAgent
     :network,
     :ignore_violations,
     :enable_weaker_nested_sandbox,
-    :ripgrep
+    :ripgrep,
+    :filesystem
   ) do
     def initialize(
       enabled: false,
@@ -122,7 +146,8 @@ module ClaudeAgent
       network: nil,
       ignore_violations: nil,
       enable_weaker_nested_sandbox: false,
-      ripgrep: nil
+      ripgrep: nil,
+      filesystem: nil
     )
       super
     end
@@ -136,6 +161,7 @@ module ClaudeAgent
       result[:ignoreViolations] = ignore_violations.to_h if ignore_violations && !ignore_violations.to_h.empty?
       result[:enableWeakerNestedSandbox] = enable_weaker_nested_sandbox if enable_weaker_nested_sandbox
       result[:ripgrep] = ripgrep.to_h if ripgrep
+      result[:filesystem] = filesystem.to_h if filesystem && !filesystem.to_h.empty?
       result
     end
   end

--- a/sig/claude_agent.rbs
+++ b/sig/claude_agent.rbs
@@ -231,6 +231,15 @@ module ClaudeAgent
     def to_h: () -> Hash[Symbol, untyped]
   end
 
+  class SandboxFilesystemConfig
+    attr_reader allow_write: Array[String]
+    attr_reader deny_write: Array[String]
+    attr_reader deny_read: Array[String]
+
+    def initialize: (?allow_write: Array[String], ?deny_write: Array[String], ?deny_read: Array[String]) -> void
+    def to_h: () -> Hash[Symbol, untyped]
+  end
+
   class SandboxSettings
     attr_reader enabled: bool
     attr_reader auto_allow_bash_if_sandboxed: bool
@@ -240,8 +249,9 @@ module ClaudeAgent
     attr_reader ignore_violations: SandboxIgnoreViolations?
     attr_reader enable_weaker_nested_sandbox: bool
     attr_reader ripgrep: SandboxRipgrepConfig?
+    attr_reader filesystem: SandboxFilesystemConfig?
 
-    def initialize: (?enabled: bool, ?auto_allow_bash_if_sandboxed: bool, ?excluded_commands: Array[String], ?allow_unsandboxed_commands: bool, ?network: SandboxNetworkConfig?, ?ignore_violations: SandboxIgnoreViolations?, ?enable_weaker_nested_sandbox: bool, ?ripgrep: SandboxRipgrepConfig?) -> void
+    def initialize: (?enabled: bool, ?auto_allow_bash_if_sandboxed: bool, ?excluded_commands: Array[String], ?allow_unsandboxed_commands: bool, ?network: SandboxNetworkConfig?, ?ignore_violations: SandboxIgnoreViolations?, ?enable_weaker_nested_sandbox: bool, ?ripgrep: SandboxRipgrepConfig?, ?filesystem: SandboxFilesystemConfig?) -> void
     def to_h: () -> Hash[Symbol, untyped]
   end
 
@@ -331,6 +341,9 @@ module ClaudeAgent
     attr_accessor include_partial_messages: bool
     attr_accessor output_format: Hash[String, untyped]?
     attr_accessor enable_file_checkpointing: bool
+
+    # Prompt suggestions
+    attr_accessor prompt_suggestions: bool
 
     # Beta features
     attr_accessor betas: Array[String]
@@ -436,7 +449,7 @@ module ClaudeAgent
   CONTENT_BLOCK_TYPES: Array[Class]
 
   # Message types
-  type message = UserMessage | UserMessageReplay | AssistantMessage | SystemMessage | ResultMessage | StreamEvent | CompactBoundaryMessage | StatusMessage | ToolProgressMessage | HookResponseMessage | AuthStatusMessage | TaskNotificationMessage | HookStartedMessage | HookProgressMessage | ToolUseSummaryMessage | FilesPersistedEvent
+  type message = UserMessage | UserMessageReplay | AssistantMessage | SystemMessage | ResultMessage | StreamEvent | CompactBoundaryMessage | StatusMessage | ToolProgressMessage | HookResponseMessage | AuthStatusMessage | TaskNotificationMessage | HookStartedMessage | HookProgressMessage | ToolUseSummaryMessage | FilesPersistedEvent | TaskStartedMessage | RateLimitEvent | PromptSuggestionMessage
 
   MESSAGE_TYPES: Array[Class]
 
@@ -673,6 +686,40 @@ module ClaudeAgent
     def type: () -> :files_persisted
   end
 
+  # Task started message (TypeScript SDK v0.2.45 parity)
+  class TaskStartedMessage
+    attr_reader uuid: String
+    attr_reader session_id: String
+    attr_reader task_id: String
+    attr_reader tool_use_id: String?
+    attr_reader description: String?
+    attr_reader task_type: String?
+
+    def initialize: (uuid: String, session_id: String, task_id: String, ?tool_use_id: String?, ?description: String?, ?task_type: String?) -> void
+    def type: () -> :task_started
+  end
+
+  # Rate limit event (TypeScript SDK v0.2.45 parity)
+  class RateLimitEvent
+    attr_reader rate_limit_info: Hash[String, untyped]
+    attr_reader uuid: String?
+    attr_reader session_id: String?
+
+    def initialize: (rate_limit_info: Hash[String, untyped], ?uuid: String?, ?session_id: String?) -> void
+    def type: () -> :rate_limit_event
+    def status: () -> String?
+  end
+
+  # Prompt suggestion message (TypeScript SDK v0.2.47 parity)
+  class PromptSuggestionMessage
+    attr_reader uuid: String?
+    attr_reader session_id: String?
+    attr_reader suggestion: String
+
+    def initialize: (?uuid: String?, ?session_id: String?, suggestion: String) -> void
+    def type: () -> :prompt_suggestion
+  end
+
   # Message parser
   class MessageParser
     def initialize: (?logger: Logger?) -> void
@@ -821,6 +868,15 @@ module ClaudeAgent
     attr_reader team_name: String?
 
     def initialize: (task_id: String, task_subject: String, ?task_description: String?, ?teammate_name: String?, ?team_name: String?, **untyped) -> void
+  end
+
+  class ConfigChangeInput < BaseHookInput
+    attr_reader source: String
+    attr_reader file_path: String?
+
+    SOURCES: Array[String]
+
+    def initialize: (source: String, ?file_path: String?, **untyped) -> void
   end
 
   # Permission types

--- a/test/claude_agent/test_hooks.rb
+++ b/test/claude_agent/test_hooks.rb
@@ -415,4 +415,50 @@ class TestClaudeAgentHooks < ActiveSupport::TestCase
     assert_equal "/home/user", input.cwd
     assert_equal "acceptEdits", input.permission_mode
   end
+
+  # --- ConfigChangeInput ---
+
+  test "config_change_event_in_hook_events" do
+    assert_includes ClaudeAgent::HOOK_EVENTS, "ConfigChange"
+  end
+
+  test "config_change_input" do
+    input = ClaudeAgent::ConfigChangeInput.new(
+      source: "user_settings",
+      file_path: "~/.claude/settings.json",
+      session_id: "sess-123"
+    )
+    assert_equal "ConfigChange", input.hook_event_name
+    assert_equal "user_settings", input.source
+    assert_equal "~/.claude/settings.json", input.file_path
+    assert_equal "sess-123", input.session_id
+  end
+
+  test "config_change_input_without_file_path" do
+    input = ClaudeAgent::ConfigChangeInput.new(source: "skills")
+    assert_equal "ConfigChange", input.hook_event_name
+    assert_equal "skills", input.source
+    assert_nil input.file_path
+  end
+
+  test "config_change_input_sources_constant" do
+    assert_includes ClaudeAgent::ConfigChangeInput::SOURCES, "user_settings"
+    assert_includes ClaudeAgent::ConfigChangeInput::SOURCES, "project_settings"
+    assert_includes ClaudeAgent::ConfigChangeInput::SOURCES, "local_settings"
+    assert_includes ClaudeAgent::ConfigChangeInput::SOURCES, "policy_settings"
+    assert_includes ClaudeAgent::ConfigChangeInput::SOURCES, "skills"
+  end
+
+  test "config_change_input_inherits_base_fields" do
+    input = ClaudeAgent::ConfigChangeInput.new(
+      source: "project_settings",
+      file_path: ".claude/settings.json",
+      transcript_path: "/path/to/transcript",
+      cwd: "/home/user",
+      permission_mode: "default"
+    )
+    assert_equal "/path/to/transcript", input.transcript_path
+    assert_equal "/home/user", input.cwd
+    assert_equal "default", input.permission_mode
+  end
 end

--- a/test/claude_agent/test_message_parser.rb
+++ b/test/claude_agent/test_message_parser.rb
@@ -875,4 +875,159 @@ class TestClaudeAgentMessageParser < ActiveSupport::TestCase
     assert_equal [], msg.failed
     assert_nil msg.processed_at
   end
+
+  # --- TaskStartedMessage parsing ---
+
+  test "parse_task_started_message" do
+    raw = {
+      "type" => "system",
+      "subtype" => "task_started",
+      "uuid" => "msg-123",
+      "session_id" => "sess-abc",
+      "task_id" => "task-456",
+      "tool_use_id" => "tool-789",
+      "description" => "Running tests",
+      "task_type" => "bash"
+    }
+    msg = @parser.parse(raw)
+
+    assert_instance_of ClaudeAgent::TaskStartedMessage, msg
+    assert_equal "msg-123", msg.uuid
+    assert_equal "sess-abc", msg.session_id
+    assert_equal "task-456", msg.task_id
+    assert_equal "tool-789", msg.tool_use_id
+    assert_equal "Running tests", msg.description
+    assert_equal "bash", msg.task_type
+    assert_equal :task_started, msg.type
+  end
+
+  test "parse_task_started_message_camel_case" do
+    raw = {
+      "type" => "system",
+      "subtype" => "task_started",
+      "uuid" => "msg-456",
+      "sessionId" => "sess-xyz",
+      "taskId" => "task-789",
+      "toolUseId" => "tool-abc",
+      "description" => "Exploring codebase",
+      "taskType" => "explore"
+    }
+    msg = @parser.parse(raw)
+
+    assert_equal "sess-xyz", msg.session_id
+    assert_equal "task-789", msg.task_id
+    assert_equal "tool-abc", msg.tool_use_id
+    assert_equal "explore", msg.task_type
+  end
+
+  test "parse_task_started_message_defaults" do
+    raw = {
+      "type" => "system",
+      "subtype" => "task_started",
+      "uuid" => "msg-123",
+      "session_id" => "sess-abc",
+      "task_id" => "task-456"
+    }
+    msg = @parser.parse(raw)
+
+    assert_nil msg.tool_use_id
+    assert_nil msg.description
+    assert_nil msg.task_type
+  end
+
+  # --- RateLimitEvent parsing ---
+
+  test "parse_rate_limit_event" do
+    raw = {
+      "type" => "rate_limit_event",
+      "uuid" => "msg-123",
+      "session_id" => "sess-abc",
+      "rate_limit_info" => {
+        "status" => "allowed_warning",
+        "resetsAt" => 1700000000,
+        "rateLimitType" => "five_hour",
+        "utilization" => 0.85,
+        "isUsingOverage" => false,
+        "overageStatus" => "available"
+      }
+    }
+    msg = @parser.parse(raw)
+
+    assert_instance_of ClaudeAgent::RateLimitEvent, msg
+    assert_equal "msg-123", msg.uuid
+    assert_equal "sess-abc", msg.session_id
+    assert_equal "allowed_warning", msg.status
+    assert_equal 0.85, msg.rate_limit_info["utilization"]
+    assert_equal :rate_limit_event, msg.type
+  end
+
+  test "parse_rate_limit_event_camel_case" do
+    raw = {
+      "type" => "rate_limit_event",
+      "uuid" => "msg-456",
+      "sessionId" => "sess-xyz",
+      "rateLimitInfo" => {
+        "status" => "blocked",
+        "rateLimitType" => "daily"
+      }
+    }
+    msg = @parser.parse(raw)
+
+    assert_equal "sess-xyz", msg.session_id
+    assert_equal "blocked", msg.status
+  end
+
+  test "parse_rate_limit_event_defaults" do
+    raw = {
+      "type" => "rate_limit_event",
+      "uuid" => "msg-123",
+      "session_id" => "sess-abc"
+    }
+    msg = @parser.parse(raw)
+
+    assert_equal({}, msg.rate_limit_info)
+    assert_nil msg.status
+  end
+
+  # --- PromptSuggestionMessage parsing ---
+
+  test "parse_prompt_suggestion_message" do
+    raw = {
+      "type" => "prompt_suggestion",
+      "uuid" => "msg-123",
+      "session_id" => "sess-abc",
+      "suggestion" => "Tell me about this project"
+    }
+    msg = @parser.parse(raw)
+
+    assert_instance_of ClaudeAgent::PromptSuggestionMessage, msg
+    assert_equal "msg-123", msg.uuid
+    assert_equal "sess-abc", msg.session_id
+    assert_equal "Tell me about this project", msg.suggestion
+    assert_equal :prompt_suggestion, msg.type
+  end
+
+  test "parse_prompt_suggestion_message_camel_case" do
+    raw = {
+      "type" => "prompt_suggestion",
+      "uuid" => "msg-456",
+      "sessionId" => "sess-xyz",
+      "suggestion" => "How do I run the tests?"
+    }
+    msg = @parser.parse(raw)
+
+    assert_equal "sess-xyz", msg.session_id
+    assert_equal "How do I run the tests?", msg.suggestion
+  end
+
+  test "parse_prompt_suggestion_message_defaults" do
+    raw = {
+      "type" => "prompt_suggestion",
+      "uuid" => "msg-123",
+      "session_id" => "sess-abc"
+    }
+    msg = @parser.parse(raw)
+
+    assert_equal "", msg.suggestion
+  end
 end

--- a/test/claude_agent/test_messages.rb
+++ b/test/claude_agent/test_messages.rb
@@ -581,4 +581,104 @@ class TestClaudeAgentMessages < ActiveSupport::TestCase
   test "files_persisted_event_in_types_constant" do
     assert_includes ClaudeAgent::MESSAGE_TYPES, ClaudeAgent::FilesPersistedEvent
   end
+
+  # --- TaskStartedMessage ---
+
+  test "task_started_message" do
+    msg = ClaudeAgent::TaskStartedMessage.new(
+      uuid: "msg-123",
+      session_id: "session-abc",
+      task_id: "task-456",
+      tool_use_id: "tool-789",
+      description: "Running tests",
+      task_type: "bash"
+    )
+    assert_equal "msg-123", msg.uuid
+    assert_equal "session-abc", msg.session_id
+    assert_equal "task-456", msg.task_id
+    assert_equal "tool-789", msg.tool_use_id
+    assert_equal "Running tests", msg.description
+    assert_equal "bash", msg.task_type
+    assert_equal :task_started, msg.type
+  end
+
+  test "task_started_message_defaults" do
+    msg = ClaudeAgent::TaskStartedMessage.new(
+      uuid: "msg-123",
+      session_id: "session-abc",
+      task_id: "task-456"
+    )
+    assert_nil msg.tool_use_id
+    assert_nil msg.description
+    assert_nil msg.task_type
+  end
+
+  test "task_started_message_in_types_constant" do
+    assert_includes ClaudeAgent::MESSAGE_TYPES, ClaudeAgent::TaskStartedMessage
+  end
+
+  # --- RateLimitEvent ---
+
+  test "rate_limit_event" do
+    info = {
+      "status" => "allowed_warning",
+      "resetsAt" => 1700000000,
+      "rateLimitType" => "five_hour",
+      "utilization" => 0.85,
+      "isUsingOverage" => false,
+      "overageStatus" => "available"
+    }
+    msg = ClaudeAgent::RateLimitEvent.new(
+      rate_limit_info: info,
+      uuid: "msg-123",
+      session_id: "session-abc"
+    )
+    assert_equal info, msg.rate_limit_info
+    assert_equal "msg-123", msg.uuid
+    assert_equal "session-abc", msg.session_id
+    assert_equal "allowed_warning", msg.status
+    assert_equal :rate_limit_event, msg.type
+  end
+
+  test "rate_limit_event_with_symbol_keys" do
+    msg = ClaudeAgent::RateLimitEvent.new(
+      rate_limit_info: { status: "blocked" }
+    )
+    assert_equal "blocked", msg.status
+  end
+
+  test "rate_limit_event_defaults" do
+    msg = ClaudeAgent::RateLimitEvent.new(rate_limit_info: {})
+    assert_nil msg.uuid
+    assert_nil msg.session_id
+    assert_nil msg.status
+  end
+
+  test "rate_limit_event_in_types_constant" do
+    assert_includes ClaudeAgent::MESSAGE_TYPES, ClaudeAgent::RateLimitEvent
+  end
+
+  # --- PromptSuggestionMessage ---
+
+  test "prompt_suggestion_message" do
+    msg = ClaudeAgent::PromptSuggestionMessage.new(
+      uuid: "msg-123",
+      session_id: "session-abc",
+      suggestion: "Tell me about this project"
+    )
+    assert_equal "msg-123", msg.uuid
+    assert_equal "session-abc", msg.session_id
+    assert_equal "Tell me about this project", msg.suggestion
+    assert_equal :prompt_suggestion, msg.type
+  end
+
+  test "prompt_suggestion_message_defaults" do
+    msg = ClaudeAgent::PromptSuggestionMessage.new(suggestion: "Hello")
+    assert_nil msg.uuid
+    assert_nil msg.session_id
+  end
+
+  test "prompt_suggestion_message_in_types_constant" do
+    assert_includes ClaudeAgent::MESSAGE_TYPES, ClaudeAgent::PromptSuggestionMessage
+  end
 end

--- a/test/claude_agent/test_options.rb
+++ b/test/claude_agent/test_options.rb
@@ -34,15 +34,10 @@ class TestClaudeAgentOptions < ActiveSupport::TestCase
   end
 
   test "valid_permission_modes" do
-    %w[default acceptEdits plan delegate dontAsk].each do |mode|
+    %w[default acceptEdits plan dontAsk].each do |mode|
       options = ClaudeAgent::Options.new(permission_mode: mode)
       assert_equal mode, options.permission_mode
     end
-  end
-
-  test "delegate_permission_mode" do
-    options = ClaudeAgent::Options.new(permission_mode: "delegate")
-    assert_equal "delegate", options.permission_mode
   end
 
   test "dont_ask_permission_mode" do
@@ -677,5 +672,29 @@ class TestClaudeAgentOptions < ActiveSupport::TestCase
     args = options.to_cli_args
     refute_includes args, "--debug"
     refute_includes args, "--debug-file"
+  end
+
+  # --- Prompt Suggestions ---
+
+  test "prompt_suggestions_default_false" do
+    options = ClaudeAgent::Options.new
+    assert_equal false, options.prompt_suggestions
+  end
+
+  test "prompt_suggestions_explicit_true" do
+    options = ClaudeAgent::Options.new(prompt_suggestions: true)
+    assert_equal true, options.prompt_suggestions
+  end
+
+  test "to_cli_args_with_prompt_suggestions" do
+    options = ClaudeAgent::Options.new(prompt_suggestions: true)
+    args = options.to_cli_args
+    assert_includes args, "--prompt-suggestions"
+  end
+
+  test "to_cli_args_without_prompt_suggestions" do
+    options = ClaudeAgent::Options.new
+    args = options.to_cli_args
+    refute_includes args, "--prompt-suggestions"
   end
 end

--- a/test/claude_agent/test_permissions.rb
+++ b/test/claude_agent/test_permissions.rb
@@ -10,9 +10,8 @@ class TestClaudeAgentPermissions < ActiveSupport::TestCase
     assert_includes ClaudeAgent::PERMISSION_MODES, "acceptEdits"
     assert_includes ClaudeAgent::PERMISSION_MODES, "plan"
     assert_includes ClaudeAgent::PERMISSION_MODES, "bypassPermissions"
-    assert_includes ClaudeAgent::PERMISSION_MODES, "delegate"
     assert_includes ClaudeAgent::PERMISSION_MODES, "dontAsk"
-    assert_equal 6, ClaudeAgent::PERMISSION_MODES.size
+    assert_equal 5, ClaudeAgent::PERMISSION_MODES.size
   end
 
   # --- Permission Update Types ---

--- a/test/claude_agent/test_sandbox_settings.rb
+++ b/test/claude_agent/test_sandbox_settings.rb
@@ -255,4 +255,93 @@ class TestClaudeAgentSandboxSettings < ActiveSupport::TestCase
     refute h.key?(:network)
     refute h.key?(:ignoreViolations)
   end
+
+  # --- SandboxFilesystemConfig ---
+
+  test "sandbox_filesystem_config" do
+    config = ClaudeAgent::SandboxFilesystemConfig.new(
+      allow_write: [ "/tmp/*", "/var/log/*" ],
+      deny_write: [ "/etc/*" ],
+      deny_read: [ "/secrets/*" ]
+    )
+    assert_equal [ "/tmp/*", "/var/log/*" ], config.allow_write
+    assert_equal [ "/etc/*" ], config.deny_write
+    assert_equal [ "/secrets/*" ], config.deny_read
+  end
+
+  test "sandbox_filesystem_config_defaults" do
+    config = ClaudeAgent::SandboxFilesystemConfig.new
+    assert_equal [], config.allow_write
+    assert_equal [], config.deny_write
+    assert_equal [], config.deny_read
+  end
+
+  test "sandbox_filesystem_config_to_h" do
+    config = ClaudeAgent::SandboxFilesystemConfig.new(
+      allow_write: [ "/tmp/*" ],
+      deny_write: [ "/etc/*" ],
+      deny_read: [ "/secrets/*" ]
+    )
+    h = config.to_h
+    assert_equal [ "/tmp/*" ], h[:allowWrite]
+    assert_equal [ "/etc/*" ], h[:denyWrite]
+    assert_equal [ "/secrets/*" ], h[:denyRead]
+  end
+
+  test "sandbox_filesystem_config_to_h_empty" do
+    config = ClaudeAgent::SandboxFilesystemConfig.new
+    assert_equal({}, config.to_h)
+  end
+
+  test "sandbox_filesystem_config_to_h_partial" do
+    config = ClaudeAgent::SandboxFilesystemConfig.new(
+      allow_write: [ "/tmp/*" ]
+    )
+    h = config.to_h
+    assert_equal [ "/tmp/*" ], h[:allowWrite]
+    refute h.key?(:denyWrite)
+    refute h.key?(:denyRead)
+  end
+
+  # --- SandboxSettings with filesystem ---
+
+  test "sandbox_settings_filesystem_default_nil" do
+    sandbox = ClaudeAgent::SandboxSettings.new
+    assert_nil sandbox.filesystem
+  end
+
+  test "sandbox_settings_with_filesystem" do
+    filesystem = ClaudeAgent::SandboxFilesystemConfig.new(
+      allow_write: [ "/tmp/*" ],
+      deny_read: [ "/secrets/*" ]
+    )
+    sandbox = ClaudeAgent::SandboxSettings.new(
+      enabled: true,
+      filesystem: filesystem
+    )
+    assert_equal filesystem, sandbox.filesystem
+    assert_equal [ "/tmp/*" ], sandbox.filesystem.allow_write
+  end
+
+  test "sandbox_settings_to_h_with_filesystem" do
+    filesystem = ClaudeAgent::SandboxFilesystemConfig.new(
+      allow_write: [ "/tmp/*" ]
+    )
+    sandbox = ClaudeAgent::SandboxSettings.new(
+      enabled: true,
+      filesystem: filesystem
+    )
+    h = sandbox.to_h
+    assert_equal({ allowWrite: [ "/tmp/*" ] }, h[:filesystem])
+  end
+
+  test "sandbox_settings_to_h_skips_empty_filesystem" do
+    filesystem = ClaudeAgent::SandboxFilesystemConfig.new
+    sandbox = ClaudeAgent::SandboxSettings.new(
+      enabled: true,
+      filesystem: filesystem
+    )
+    h = sandbox.to_h
+    refute h.key?(:filesystem)
+  end
 end


### PR DESCRIPTION
## What
Implements 6 missing features from TypeScript SDK v0.2.43-v0.2.49 to bring the Ruby SDK to full parity.

## Why
SPEC.md identified these as gaps where the TypeScript SDK had features the Ruby SDK was missing. All 6 are medium priority (Python SDK also missing them).

## How
- **3 new message types**: `TaskStartedMessage` (v0.2.45), `RateLimitEvent` (v0.2.45), `PromptSuggestionMessage` (v0.2.47) — Data.define types with parser dispatch
- **`promptSuggestions` option** (v0.2.47) — CLI arg `--prompt-suggestions` + `promptSuggestions: true` in control protocol initialize
- **`ConfigChange` hook event** (v0.2.49) — Added to `HOOK_EVENTS` with `ConfigChangeInput` class
- **`SandboxFilesystemConfig`** (v0.2.49) — New Data.define with `allow_write`/`deny_write`/`deny_read`, added as `filesystem` field on `SandboxSettings`
- RBS signatures for all new types
- SPEC.md updated (10 cells flipped from ❌ to ✅)

## Test plan
- [x] `bundle exec rake test` — 542 tests, 1595 assertions, 0 failures
- [x] `bundle exec rake rbs` — validates cleanly
- [x] `bundle exec rubocop` — 0 offenses