### PR TITLE
feat: implement TypeScript SDK v0.2.50 feature parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `WorktreeCreate` hook event with `WorktreeCreateInput` class (TypeScript SDK v0.2.50 parity)
+- `WorktreeRemove` hook event with `WorktreeRemoveInput` class (TypeScript SDK v0.2.50 parity)
+- `apply_flag_settings` control request on `ControlProtocol` and `Client` for merging settings into the flag layer (TypeScript SDK v0.2.50 parity)
+- RBS signatures for all new types
+
 ## [0.7.7] - 2026-02-20
 
 ### Added

--- a/SPEC.md
+++ b/SPEC.md
@@ -3,11 +3,11 @@
 This document provides a comprehensive specification of the Claude Agent SDK, comparing feature parity across the official TypeScript and Python SDKs with this Ruby implementation.
 
 **Reference Versions:**
-- TypeScript SDK: v0.2.49 (npm package)
+- TypeScript SDK: v0.2.50 (npm package)
 - Python SDK: v0.1.39 from GitHub (commit 146e3d6)
 - Ruby SDK: This repository
 
-**Last Updated:** 2026-02-20
+**Last Updated:** 2026-02-22
 
 ---
 
@@ -235,6 +235,7 @@ Bidirectional control protocol for SDK-CLI communication.
 | `supported_commands`      |     ✅      |   ❌    |  ✅   | Get available slash commands      |
 | `supported_models`        |     ✅      |   ❌    |  ✅   | Get available models              |
 | `account_info`            |     ✅      |   ❌    |  ✅   | Get account information           |
+| `apply_flag_settings`     |     ✅      |   ❌    |  ✅   | Merge settings into flag layer    |
 
 ### Return Types
 
@@ -274,6 +275,8 @@ Event hooks for intercepting and modifying SDK behavior.
 | `TeammateIdle`       |     ✅      |   ❌    |  ✅   | Teammate idle (v0.2.33)           |
 | `TaskCompleted`      |     ✅      |   ❌    |  ✅   | Task completed (v0.2.33)          |
 | `ConfigChange`       |     ✅      |   ❌    |  ✅   | Config file changed (v0.2.49)     |
+| `WorktreeCreate`     |     ✅      |   ❌    |  ✅   | Worktree creation (v0.2.50)       |
+| `WorktreeRemove`     |     ✅      |   ❌    |  ✅   | Worktree removal (v0.2.50)        |
 
 ### Hook Input Types
 
@@ -295,6 +298,8 @@ Event hooks for intercepting and modifying SDK behavior.
 | `TeammateIdleHookInput`       |     ✅      |   ❌    |  ✅   |
 | `TaskCompletedHookInput`      |     ✅      |   ❌    |  ✅   |
 | `ConfigChangeHookInput`       |     ✅      |   ❌    |  ✅   |
+| `WorktreeCreateHookInput`     |     ✅      |   ❌    |  ✅   |
+| `WorktreeRemoveHookInput`     |     ✅      |   ❌    |  ✅   |
 
 ### Hook Output Types
 
@@ -690,11 +695,12 @@ Public API surface for SDK clients.
 - v0.2.45: Added `TaskStartedMessage`, `RateLimitEvent` message types
 - v0.2.47: Added `promptSuggestions` option and `PromptSuggestionMessage`
 - v0.2.49: Added `ConfigChange` hook event, `SandboxFilesystemConfig`
+- v0.2.50: Added `WorktreeCreate`/`WorktreeRemove` hook events, `apply_flag_settings` control request
 
 ### Python SDK
 - Full source available with `Transport` abstract class
 - Partial control protocol: query and client support interrupt, setPermissionMode, setModel, rewindFiles, mcpStatus
-- Missing hooks: SessionStart, SessionEnd, Setup, TeammateIdle, TaskCompleted, ConfigChange
+- Missing hooks: SessionStart, SessionEnd, Setup, TeammateIdle, TaskCompleted, ConfigChange, WorktreeCreate, WorktreeRemove
 - Missing permission modes: `dontAsk`
 - Missing options: `allowDangerouslySkipPermissions`, `persistSession`, `resumeSessionAt`, `sessionId`, `strictMcpConfig`, `init`/`initOnly`/`maintenance`, `debug`/`debugFile`, `promptSuggestions`
 - `ToolPermissionContext` missing `blockedPath`, `decisionReason`, `toolUseID`, `agentID`, `description`
@@ -703,9 +709,8 @@ Public API surface for SDK clients.
 - Handles `rate_limit_event` and unknown message types gracefully (v0.1.39)
 
 ### Ruby SDK (This Repository)
-- Feature parity with TypeScript SDK v0.2.42
+- Feature parity with TypeScript SDK v0.2.50
 - Ruby-idiomatic patterns (Data.define, snake_case)
 - Complete control protocol, hook, and V2 Session API support
 - Dedicated Client class for multi-turn conversations
 - `executable`/`executableArgs` marked N/A (JS runtime options)
-- Gaps from TS v0.2.43-v0.2.49: `promptSuggestions`, `TaskStartedMessage`, `RateLimitEvent`, `PromptSuggestionMessage`, `ConfigChange` hook, `SandboxFilesystemConfig`

--- a/lib/claude_agent/client.rb
+++ b/lib/claude_agent/client.rb
@@ -298,6 +298,22 @@ module ClaudeAgent
       @protocol.stop_task(task_id)
     end
 
+    # Apply flag settings (TypeScript SDK v0.2.50 parity)
+    #
+    # Merges the provided settings into the flag settings layer.
+    #
+    # @param settings [Hash] Settings to merge into the flag layer
+    # @return [Hash] Response from the CLI
+    #
+    # @example
+    #   client.apply_flag_settings({ "model" => "claude-sonnet-4-5-20250514" })
+    #
+    def apply_flag_settings(settings)
+      require_connection!
+
+      @protocol.apply_flag_settings(settings)
+    end
+
     # Dynamically set MCP servers for this session (TypeScript SDK parity)
     #
     # This replaces the current set of dynamically-added MCP servers.

--- a/lib/claude_agent/control_protocol.rb
+++ b/lib/claude_agent/control_protocol.rb
@@ -458,6 +458,20 @@ module ClaudeAgent
       send_control_request(subtype: "stop_task", task_id: task_id)
     end
 
+    # Apply flag settings (TypeScript SDK v0.2.50 parity)
+    #
+    # Merges the provided settings into the flag settings layer.
+    #
+    # @param settings [Hash] Settings to merge into the flag layer
+    # @return [Hash] Response from the CLI
+    #
+    # @example
+    #   protocol.apply_flag_settings({ "model" => "claude-sonnet-4-5-20250514" })
+    #
+    def apply_flag_settings(settings)
+      send_control_request(subtype: "apply_flag_settings", settings: settings)
+    end
+
     # Dynamically set MCP servers for this session (TypeScript SDK parity)
     #
     # This replaces the current set of dynamically-added MCP servers.

--- a/lib/claude_agent/hooks.rb
+++ b/lib/claude_agent/hooks.rb
@@ -19,6 +19,8 @@ module ClaudeAgent
     TeammateIdle
     TaskCompleted
     ConfigChange
+    WorktreeCreate
+    WorktreeRemove
   ].freeze
 
   # Matcher configuration for hooks
@@ -301,6 +303,34 @@ module ClaudeAgent
       super(hook_event_name: "ConfigChange", **kwargs)
       @source = source
       @file_path = file_path
+    end
+  end
+
+  # Input for WorktreeCreate hook (TypeScript SDK v0.2.50 parity)
+  #
+  # Fired when a worktree is created.
+  #
+  class WorktreeCreateInput < BaseHookInput
+    attr_reader :name
+
+    # @param name [String] Worktree name
+    def initialize(name:, **kwargs)
+      super(hook_event_name: "WorktreeCreate", **kwargs)
+      @name = name
+    end
+  end
+
+  # Input for WorktreeRemove hook (TypeScript SDK v0.2.50 parity)
+  #
+  # Fired when a worktree is removed.
+  #
+  class WorktreeRemoveInput < BaseHookInput
+    attr_reader :worktree_path
+
+    # @param worktree_path [String] Path to the worktree
+    def initialize(worktree_path:, **kwargs)
+      super(hook_event_name: "WorktreeRemove", **kwargs)
+      @worktree_path = worktree_path
     end
   end
 

--- a/sig/claude_agent.rbs
+++ b/sig/claude_agent.rbs
@@ -879,6 +879,18 @@ module ClaudeAgent
     def initialize: (source: String, ?file_path: String?, **untyped) -> void
   end
 
+  class WorktreeCreateInput < BaseHookInput
+    attr_reader name: String
+
+    def initialize: (name: String, **untyped) -> void
+  end
+
+  class WorktreeRemoveInput < BaseHookInput
+    attr_reader worktree_path: String
+
+    def initialize: (worktree_path: String, **untyped) -> void
+  end
+
   # Permission types
   type permission_result = PermissionResultAllow | PermissionResultDeny
 
@@ -967,6 +979,7 @@ module ClaudeAgent
     def mcp_reconnect: (String server_name) -> Hash[String, untyped]
     def mcp_toggle: (String server_name, enabled: bool) -> Hash[String, untyped]
     def stop_task: (String task_id) -> Hash[String, untyped]
+    def apply_flag_settings: (Hash[String, untyped] settings) -> Hash[String, untyped]
     def supported_commands: () -> Array[SlashCommand]
     def supported_models: () -> Array[ModelInfo]
     def mcp_server_status: () -> Array[McpServerStatus]
@@ -1004,6 +1017,7 @@ module ClaudeAgent
     def mcp_reconnect: (String server_name) -> Hash[String, untyped]
     def mcp_toggle: (String server_name, enabled: bool) -> Hash[String, untyped]
     def stop_task: (String task_id) -> Hash[String, untyped]
+    def apply_flag_settings: (Hash[String, untyped] settings) -> Hash[String, untyped]
     def supported_commands: () -> Array[SlashCommand]
     def supported_models: () -> Array[ModelInfo]
     def mcp_server_status: () -> Array[McpServerStatus]

--- a/test/claude_agent/test_control_protocol.rb
+++ b/test/claude_agent/test_control_protocol.rb
@@ -335,6 +335,21 @@ class TestClaudeAgentControlProtocol < ActiveSupport::TestCase
     assert_equal "task-123", msg["request"]["task_id"]
   end
 
+  test "apply_flag_settings sends correct request format" do
+    @transport.connect
+
+    @protocol.send(:write_message, {
+      type: "control_request",
+      request_id: "test-req",
+      request: { subtype: "apply_flag_settings", settings: { "model" => "claude-sonnet-4-5-20250514" } }
+    })
+
+    msg = @transport.written_messages.find { |m| m["type"] == "control_request" }
+    assert_not_nil msg
+    assert_equal "apply_flag_settings", msg["request"]["subtype"]
+    assert_equal({ "model" => "claude-sonnet-4-5-20250514" }, msg["request"]["settings"])
+  end
+
   test "mcp_toggle sends correct request format" do
     @transport.connect
 

--- a/test/claude_agent/test_hooks.rb
+++ b/test/claude_agent/test_hooks.rb
@@ -449,6 +449,62 @@ class TestClaudeAgentHooks < ActiveSupport::TestCase
     assert_includes ClaudeAgent::ConfigChangeInput::SOURCES, "skills"
   end
 
+  # --- WorktreeCreateInput ---
+
+  test "worktree_create_event_in_hook_events" do
+    assert_includes ClaudeAgent::HOOK_EVENTS, "WorktreeCreate"
+  end
+
+  test "worktree_create_input" do
+    input = ClaudeAgent::WorktreeCreateInput.new(
+      name: "feature-branch",
+      session_id: "sess-123"
+    )
+    assert_equal "WorktreeCreate", input.hook_event_name
+    assert_equal "feature-branch", input.name
+    assert_equal "sess-123", input.session_id
+  end
+
+  test "worktree_create_input_inherits_base_fields" do
+    input = ClaudeAgent::WorktreeCreateInput.new(
+      name: "my-worktree",
+      transcript_path: "/path/to/transcript",
+      cwd: "/home/user",
+      permission_mode: "default"
+    )
+    assert_equal "/path/to/transcript", input.transcript_path
+    assert_equal "/home/user", input.cwd
+    assert_equal "default", input.permission_mode
+  end
+
+  # --- WorktreeRemoveInput ---
+
+  test "worktree_remove_event_in_hook_events" do
+    assert_includes ClaudeAgent::HOOK_EVENTS, "WorktreeRemove"
+  end
+
+  test "worktree_remove_input" do
+    input = ClaudeAgent::WorktreeRemoveInput.new(
+      worktree_path: "/tmp/worktrees/feature-branch",
+      session_id: "sess-456"
+    )
+    assert_equal "WorktreeRemove", input.hook_event_name
+    assert_equal "/tmp/worktrees/feature-branch", input.worktree_path
+    assert_equal "sess-456", input.session_id
+  end
+
+  test "worktree_remove_input_inherits_base_fields" do
+    input = ClaudeAgent::WorktreeRemoveInput.new(
+      worktree_path: "/tmp/worktrees/cleanup",
+      transcript_path: "/path/to/transcript",
+      cwd: "/home/user",
+      permission_mode: "acceptEdits"
+    )
+    assert_equal "/path/to/transcript", input.transcript_path
+    assert_equal "/home/user", input.cwd
+    assert_equal "acceptEdits", input.permission_mode
+  end
+
   test "config_change_input_inherits_base_fields" do
     input = ClaudeAgent::ConfigChangeInput.new(
       source: "project_settings",


### PR DESCRIPTION
## What
Implements the 3 remaining features from TypeScript SDK v0.2.50 to reach full parity.

## Why
The Ruby SDK was tracking v0.2.49 parity. This closes the gap with v0.2.50.

## How
- **WorktreeCreate/WorktreeRemove hook events**: Added to `HOOK_EVENTS` with corresponding `WorktreeCreateInput` (field: `name`) and `WorktreeRemoveInput` (field: `worktree_path`) classes
- **apply_flag_settings control request**: Added to `ControlProtocol` and `Client` for merging settings into the flag settings layer
- Updated RBS signatures, unit tests, CHANGELOG, and SPEC.md parity markers